### PR TITLE
Make notification and qualifying-event request generation API-version aware

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/NotificationBundle.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/NotificationBundle.java
@@ -24,11 +24,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Bundle of notification related responses for easier processing
  */
 public class NotificationBundle {
+    private ApiVersion apiVersion;
     private AlertStatusResponse alertStatusResponse;
     private ReminderStatusResponse reminderStatusResponse;
     private AlarmStatusResponse alarmStatusResponse;
@@ -40,7 +42,15 @@ public class NotificationBundle {
     private Map<Class<? extends Message>, Instant> lastUpdatedTimes = new HashMap<>();
 
     public static List<Message> allRequests() {
-        return Arrays.asList(
+        return allRequests(null);
+    }
+
+    public List<Message> allRequestsForPump() {
+        return allRequests(apiVersion);
+    }
+
+    public static List<Message> allRequests(ApiVersion apiVersion) {
+        List<Message> requests = Arrays.asList(
                 new AlertStatusRequest(),
                 new AlarmStatusRequest(),
                 new CGMAlertStatusRequest(),
@@ -49,6 +59,20 @@ public class NotificationBundle {
                 new ActiveAamBitsRequest(new byte[]{2}),
                 new ActiveAamBitsRequest(new byte[]{4})
         );
+
+        if (apiVersion == null) {
+            return requests;
+        }
+
+        return requests.stream()
+                .filter(request -> supportsApiVersion(request, apiVersion))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean supportsApiVersion(Message message, ApiVersion apiVersion) {
+        ApiVersion minApi = message.props().minApi().get();
+        return apiVersion.greaterThan(minApi) ||
+                (apiVersion.getMajor() == minApi.getMajor() && apiVersion.getMinor() == minApi.getMinor());
     }
 
     public static List<Class<? extends Message>> responseClasses() {
@@ -74,7 +98,12 @@ public class NotificationBundle {
     public NotificationBundle() {
     }
 
+    public NotificationBundle(ApiVersion apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
     public NotificationBundle(NotificationBundle bundle) {
+        this.apiVersion = bundle.apiVersion;
         this.alertStatusResponse = bundle.alertStatusResponse;
         this.reminderStatusResponse = bundle.reminderStatusResponse;
         this.alarmStatusResponse = bundle.alarmStatusResponse;
@@ -83,6 +112,14 @@ public class NotificationBundle {
         this.activeAamBitsResponses = new HashMap<>(bundle.activeAamBitsResponses);
         this.highestAamResponse = bundle.highestAamResponse;
         this.lastUpdatedTimes = bundle.lastUpdatedTimes;
+    }
+
+    public void setApiVersion(ApiVersion apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public ApiVersion getApiVersion() {
+        return apiVersion;
     }
 
     public NotificationBundle add(Message message) {

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/qualifyingEvent/QualifyingEvent.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/qualifyingEvent/QualifyingEvent.java
@@ -7,6 +7,7 @@ import com.jwoglom.pumpx2.pump.messages.builders.CurrentBatteryRequestBuilder;
 import com.jwoglom.pumpx2.pump.messages.builders.IOBRequestBuilder;
 import com.jwoglom.pumpx2.pump.messages.builders.LastBolusStatusRequestBuilder;
 import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
+import com.jwoglom.pumpx2.pump.messages.models.ApiVersion;
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ActiveAamBitsRequest;
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.AlarmStatusRequest;
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.AlertStatusRequest;
@@ -183,11 +184,32 @@ public enum QualifyingEvent {
     }
 
     public static Set<? extends Message> groupSuggestedHandlers(Set<QualifyingEvent> events) {
+        ApiVersion apiVersion = null;
+        if (PumpStateSupplier.pumpApiVersion != null) {
+            apiVersion = PumpStateSupplier.pumpApiVersion.get();
+        }
+        return groupSuggestedHandlers(events, apiVersion);
+    }
+
+    public static Set<? extends Message> groupSuggestedHandlers(Set<QualifyingEvent> events, ApiVersion apiVersion) {
         Set<Supplier<? extends Message>> messages = new HashSet<>();
         for (QualifyingEvent e : events) {
             messages.addAll(e.suggestedHandlers);
         }
-        return messages.stream().map(Supplier::get).collect(Collectors.toSet());
+        return messages.stream()
+                .map(Supplier::get)
+                .filter(message -> message != null && supportsApiVersion(message, apiVersion))
+                .collect(Collectors.toSet());
+    }
+
+    private static boolean supportsApiVersion(Message message, ApiVersion apiVersion) {
+        if (apiVersion == null) {
+            return true;
+        }
+
+        ApiVersion minApi = message.props().minApi().get();
+        return apiVersion.greaterThan(minApi) ||
+                (apiVersion.getMajor() == minApi.getMajor() && apiVersion.getMinor() == minApi.getMinor());
     }
 
     public static int toBitmask(QualifyingEvent...states) {

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/models/NotificationBundleTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/models/NotificationBundleTest.java
@@ -1,13 +1,20 @@
 package com.jwoglom.pumpx2.pump.messages.models;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import com.jwoglom.pumpx2.pump.messages.Message;
+import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ActiveAamBitsRequest;
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.ActiveAamBitsResponse;
 import com.jwoglom.pumpx2.pump.messages.response.currentStatus.HighestAamResponse;
 
 import org.junit.Test;
 
 import java.math.BigInteger;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class NotificationBundleTest {
     @Test
@@ -40,5 +47,44 @@ public class NotificationBundleTest {
         bundle.add(activeMatch);
 
         assertEquals(1, bundle.getNotificationCount());
+    }
+
+    @Test
+    public void testApiVersionConstructorAndSetter() {
+        NotificationBundle bundle = new NotificationBundle(KnownApiVersion.API_V2_5.get());
+        assertEquals(KnownApiVersion.API_V2_5.get().serialize(), bundle.getApiVersion().serialize());
+
+        bundle.setApiVersion(KnownApiVersion.MOBI_API_V3_5.get());
+        assertEquals(KnownApiVersion.MOBI_API_V3_5.get().serialize(), bundle.getApiVersion().serialize());
+
+        NotificationBundle copied = new NotificationBundle(bundle);
+        assertEquals(KnownApiVersion.MOBI_API_V3_5.get().serialize(), copied.getApiVersion().serialize());
+
+        bundle.setApiVersion(null);
+        assertNull(bundle.getApiVersion());
+    }
+
+    @Test
+    public void testAllRequestsFiltersUnsupportedApiDependentRequests() {
+        Set<Class<? extends Message>> oldApiClasses = NotificationBundle.allRequests(KnownApiVersion.API_V2_1.get())
+                .stream().map(Message::getClass).collect(Collectors.toSet());
+        assertFalse(oldApiClasses.contains(ActiveAamBitsRequest.class));
+
+        Set<Class<? extends Message>> mobiApiClasses = NotificationBundle.allRequests(KnownApiVersion.MOBI_API_V3_5.get())
+                .stream().map(Message::getClass).collect(Collectors.toSet());
+        assertTrue(mobiApiClasses.contains(ActiveAamBitsRequest.class));
+    }
+
+    @Test
+    public void testAllRequestsForPumpUsesBundleApiVersion() {
+        NotificationBundle bundle = new NotificationBundle(KnownApiVersion.API_V2_1.get());
+        Set<Class<? extends Message>> requestClasses = bundle.allRequestsForPump()
+                .stream().map(Message::getClass).collect(Collectors.toSet());
+        assertFalse(requestClasses.contains(ActiveAamBitsRequest.class));
+
+        bundle.setApiVersion(KnownApiVersion.MOBI_API_V3_5.get());
+        Set<Class<? extends Message>> mobiRequestClasses = bundle.allRequestsForPump()
+                .stream().map(Message::getClass).collect(Collectors.toSet());
+        assertTrue(mobiRequestClasses.contains(ActiveAamBitsRequest.class));
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/qualifyingEvent/QualifyingEventTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/qualifyingEvent/QualifyingEventTest.java
@@ -1,6 +1,7 @@
 package com.jwoglom.pumpx2.pump.messages.response.qualifyingEvent;
 
 import com.jwoglom.pumpx2.pump.messages.Message;
+import com.jwoglom.pumpx2.pump.messages.models.KnownApiVersion;
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ActiveAamBitsRequest;
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.AlarmStatusRequest;
 import com.jwoglom.pumpx2.pump.messages.request.currentStatus.BasalLimitSettingsRequest;
@@ -146,6 +147,29 @@ public class QualifyingEventTest {
     public void testQualifyingEvent_groupSuggestedHandlers_pumpingStatusChangeUsesLoadStatus() {
         Set<? extends Message> messages = QualifyingEvent.groupSuggestedHandlers(Set.of(PUMPING_STATUS));
         assertEquals(Set.of(LoadStatusRequest.class), messageClasses(messages));
+    }
+
+    @Test
+    public void testQualifyingEvent_groupSuggestedHandlers_excludesUnsupportedForOlderApi() {
+        Set<? extends Message> messages = QualifyingEvent.groupSuggestedHandlers(
+                Set.of(ALARM, BOLUS_PERMISSION_REVOKED),
+                KnownApiVersion.API_V2_1.get());
+        assertEquals(Set.of(
+                        AlarmStatusRequest.class,
+                        HighestAamRequest.class),
+                messageClasses(messages));
+    }
+
+    @Test
+    public void testQualifyingEvent_groupSuggestedHandlers_includesSupportedForMobiApi() {
+        Set<? extends Message> messages = QualifyingEvent.groupSuggestedHandlers(
+                Set.of(ALARM),
+                KnownApiVersion.MOBI_API_V3_5.get());
+        assertEquals(Set.of(
+                        AlarmStatusRequest.class,
+                        HighestAamRequest.class,
+                        ActiveAamBitsRequest.class),
+                messageClasses(messages));
     }
 
     private static Set<Class<? extends Message>> messageClasses(Set<? extends Message> messages) {


### PR DESCRIPTION
### Motivation
- Ensure only pump-supported requests are generated for notifications and qualifying events by considering pump `ApiVersion` metadata.

### Description
- Added an `apiVersion` field, constructor, `setApiVersion` and `getApiVersion` to `NotificationBundle` and updated the copy constructor to preserve it.
- Split `NotificationBundle.allRequests()` into `allRequests()`/`allRequests(ApiVersion)` and added `allRequestsForPump()` that uses the bundle `apiVersion`; added `supportsApiVersion` filtering to exclude requests whose `minApi` is newer than the pump API.
- Made `QualifyingEvent.groupSuggestedHandlers` API-aware by adding an overload that accepts `ApiVersion`, by default pulling the version from `PumpStateSupplier.pumpApiVersion`, and filtering suggested handler requests with a `supportsApiVersion` check.
- Added imports and minor stream-based collection logic, and updated tests to cover the new API-version behavior.

### Testing
- Ran unit tests in `messages` module including `NotificationBundleTest` and `QualifyingEventTest`, which exercise `NotificationBundle` API constructor/setter, `allRequests` filtering, `allRequestsForPump`, and `groupSuggestedHandlers` API filtering; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08cd189c8832c878204816ba636fc)