### PR TITLE
Implement Comparable for ApiVersion and refactor version comparisons

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/ApiVersion.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/ApiVersion.java
@@ -1,8 +1,10 @@
 package com.jwoglom.pumpx2.pump.messages.models;
 
+import java.util.Objects;
+
 import org.apache.commons.lang3.Validate;
 
-public class ApiVersion {
+public class ApiVersion implements Comparable<ApiVersion> {
 
     private final int major;
     private final int minor;
@@ -19,12 +21,36 @@ public class ApiVersion {
         return minor;
     }
 
+    @Override
+    public int compareTo(ApiVersion other) {
+        int cmp = Integer.compare(getMajor(), other.getMajor());
+        if (cmp != 0) return cmp;
+        return Integer.compare(getMinor(), other.getMinor());
+    }
+
+    public int compareTo(KnownApiVersion other) {
+        return compareTo(other.get());
+    }
+
     public boolean greaterThan(ApiVersion other) {
-        return getMajor() > other.getMajor() || (getMajor() == other.getMajor() && getMinor() > other.getMinor());
+        return compareTo(other) > 0;
     }
 
     public boolean greaterThan(KnownApiVersion other) {
-        return greaterThan(other.get());
+        return compareTo(other) > 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiVersion that = (ApiVersion) o;
+        return major == that.major && minor == that.minor;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor);
     }
 
     public String toString() {

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/KnownApiVersion.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/KnownApiVersion.java
@@ -32,4 +32,20 @@ public enum KnownApiVersion {
     public ApiVersion get() {
         return new ApiVersion(major, minor);
     }
+
+    public int compareVersionTo(KnownApiVersion other) {
+        return get().compareTo(other.get());
+    }
+
+    public int compareVersionTo(ApiVersion other) {
+        return get().compareTo(other);
+    }
+
+    public boolean greaterThan(KnownApiVersion other) {
+        return compareVersionTo(other) > 0;
+    }
+
+    public boolean greaterThan(ApiVersion other) {
+        return compareVersionTo(other) > 0;
+    }
 }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/NotificationBundle.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/models/NotificationBundle.java
@@ -71,8 +71,7 @@ public class NotificationBundle {
 
     private static boolean supportsApiVersion(Message message, ApiVersion apiVersion) {
         ApiVersion minApi = message.props().minApi().get();
-        return apiVersion.greaterThan(minApi) ||
-                (apiVersion.getMajor() == minApi.getMajor() && apiVersion.getMinor() == minApi.getMinor());
+        return apiVersion.compareTo(minApi) >= 0;
     }
 
     public static List<Class<? extends Message>> responseClasses() {

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/qualifyingEvent/QualifyingEvent.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/qualifyingEvent/QualifyingEvent.java
@@ -208,8 +208,7 @@ public enum QualifyingEvent {
         }
 
         ApiVersion minApi = message.props().minApi().get();
-        return apiVersion.greaterThan(minApi) ||
-                (apiVersion.getMajor() == minApi.getMajor() && apiVersion.getMinor() == minApi.getMinor());
+        return apiVersion.compareTo(minApi) >= 0;
     }
 
     public static int toBitmask(QualifyingEvent...states) {


### PR DESCRIPTION
## Summary
This PR refactors API version comparison logic by implementing the `Comparable<ApiVersion>` interface and adding helper methods to both `ApiVersion` and `KnownApiVersion` classes. This improves code maintainability and reduces duplication of comparison logic.

## Key Changes
- **ApiVersion class**:
  - Implements `Comparable<ApiVersion>` interface with `compareTo()` method
  - Added overloaded `compareTo(KnownApiVersion)` method
  - Implemented `equals()` and `hashCode()` methods for proper object equality
  - Refactored `greaterThan()` methods to use the new `compareTo()` implementation

- **KnownApiVersion enum**:
  - Added `compareVersionTo(KnownApiVersion)` and `compareVersionTo(ApiVersion)` methods
  - Added `greaterThan(KnownApiVersion)` and `greaterThan(ApiVersion)` convenience methods

- **NotificationBundle and QualifyingEvent classes**:
  - Simplified `supportsApiVersion()` logic by replacing manual comparison with `compareTo(minApi) >= 0`
  - Eliminates redundant equality checks

## Implementation Details
- The `compareTo()` method follows standard comparison semantics: compares major version first, then minor version if major versions are equal
- All existing comparison behavior is preserved while reducing code duplication
- The refactoring makes version comparison more consistent and easier to test

https://claude.ai/code/session_01ShTZc4RWoaLqWAcyiUSCpc