### PR TITLE
Parse and construct CGM FSL2/FSL3 history logs; add getters and tests

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl2HistoryLog.java
@@ -11,11 +11,33 @@ import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
 )
 public class CgmDataFsl2HistoryLog extends HistoryLog {
 
+    private int status;
+    private int type;
+    private int rate;
+    private int rssi;
+    private int value;
+    private long timestamp;
+    private long transmitterTimestamp;
+
     public CgmDataFsl2HistoryLog() {}
     public CgmDataFsl2HistoryLog(long pumpTimeSec, long sequenceNum) {
-        super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum);
+        this(pumpTimeSec, sequenceNum, 0, 0, 0, 0, 0, 0, 0);
+    }
 
+    public CgmDataFsl2HistoryLog(long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
+        super(pumpTimeSec, sequenceNum);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, status, type, rate, rssi, value, timestamp, transmitterTimestamp);
+        this.status = status;
+        this.type = type;
+        this.rate = rate;
+        this.rssi = rssi;
+        this.value = value;
+        this.timestamp = timestamp;
+        this.transmitterTimestamp = transmitterTimestamp;
+    }
+
+    public CgmDataFsl2HistoryLog(int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
+        this(0, 0, status, type, rate, rssi, value, timestamp, transmitterTimestamp);
     }
 
     public int typeId() {
@@ -26,13 +48,57 @@ public class CgmDataFsl2HistoryLog extends HistoryLog {
         Validate.isTrue(raw.length == 26);
         this.cargo = raw;
         parseBase(raw);
+        this.status = Bytes.readShort(raw, 10);
+        this.type = raw[12];
+        this.rate = raw[13];
+        this.rssi = raw[15];
+        this.value = Bytes.readShort(raw, 16);
+        this.timestamp = Bytes.readUint32(raw, 18);
+        this.transmitterTimestamp = Bytes.readUint32(raw, 22);
 
     }
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
+        return buildCargo(pumpTimeSec, sequenceNum, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 372, 0},
+            new byte[]{(byte)(372 & 0xFF), (byte)(372 >> 8)}, // 372 = 0x0174
             Bytes.toUint32(pumpTimeSec),
-            Bytes.toUint32(sequenceNum)));
+            Bytes.toUint32(sequenceNum),
+            Bytes.firstTwoBytesLittleEndian(status),
+            new byte[]{(byte) type},
+            new byte[]{(byte) rate},
+            new byte[]{0},
+            new byte[]{(byte) rssi},
+            Bytes.firstTwoBytesLittleEndian(value),
+            Bytes.toUint32(timestamp),
+            Bytes.toUint32(transmitterTimestamp)));
+    }
+
+    public int getStatus() {
+        return status;
+    }
+    public int getType() {
+        return type;
+    }
+    public int getRate() {
+        return rate;
+    }
+    public int getRssi() {
+        return rssi;
+    }
+    /**
+     * @return the glucose value in mg/dL
+     */
+    public int getValue() {
+        return value;
+    }
+    public long getTimestamp() {
+        return timestamp;
+    }
+    public long getTransmitterTimestamp() {
+        return transmitterTimestamp;
     }
 }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl3HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl3HistoryLog.java
@@ -11,11 +11,33 @@ import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
 )
 public class CgmDataFsl3HistoryLog extends HistoryLog {
 
+    private int status;
+    private int type;
+    private int rate;
+    private int rssi;
+    private int value;
+    private long timestamp;
+    private long transmitterTimestamp;
+
     public CgmDataFsl3HistoryLog() {}
     public CgmDataFsl3HistoryLog(long pumpTimeSec, long sequenceNum) {
-        super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum);
+        this(pumpTimeSec, sequenceNum, 0, 0, 0, 0, 0, 0, 0);
+    }
 
+    public CgmDataFsl3HistoryLog(long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
+        super(pumpTimeSec, sequenceNum);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, status, type, rate, rssi, value, timestamp, transmitterTimestamp);
+        this.status = status;
+        this.type = type;
+        this.rate = rate;
+        this.rssi = rssi;
+        this.value = value;
+        this.timestamp = timestamp;
+        this.transmitterTimestamp = transmitterTimestamp;
+    }
+
+    public CgmDataFsl3HistoryLog(int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
+        this(0, 0, status, type, rate, rssi, value, timestamp, transmitterTimestamp);
     }
 
     public int typeId() {
@@ -26,13 +48,57 @@ public class CgmDataFsl3HistoryLog extends HistoryLog {
         Validate.isTrue(raw.length == 26);
         this.cargo = raw;
         parseBase(raw);
+        this.status = Bytes.readShort(raw, 10);
+        this.type = raw[12];
+        this.rate = raw[13];
+        this.rssi = raw[15];
+        this.value = Bytes.readShort(raw, 16);
+        this.timestamp = Bytes.readUint32(raw, 18);
+        this.transmitterTimestamp = Bytes.readUint32(raw, 22);
 
     }
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
+        return buildCargo(pumpTimeSec, sequenceNum, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{(byte)(480 & 0xFF), (byte)(480 >> 8)}, // 480 = 0x01E0
             Bytes.toUint32(pumpTimeSec),
-            Bytes.toUint32(sequenceNum)));
+            Bytes.toUint32(sequenceNum),
+            Bytes.firstTwoBytesLittleEndian(status),
+            new byte[]{(byte) type},
+            new byte[]{(byte) rate},
+            new byte[]{0},
+            new byte[]{(byte) rssi},
+            Bytes.firstTwoBytesLittleEndian(value),
+            Bytes.toUint32(timestamp),
+            Bytes.toUint32(transmitterTimestamp)));
+    }
+
+    public int getStatus() {
+        return status;
+    }
+    public int getType() {
+        return type;
+    }
+    public int getRate() {
+        return rate;
+    }
+    public int getRssi() {
+        return rssi;
+    }
+    /**
+     * @return the glucose value in mg/dL
+     */
+    public int getValue() {
+        return value;
+    }
+    public long getTimestamp() {
+        return timestamp;
+    }
+    public long getTransmitterTimestamp() {
+        return transmitterTimestamp;
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl2HistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl2HistoryLogTest.java
@@ -1,0 +1,30 @@
+package com.jwoglom.pumpx2.pump.messages.response.historyLog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CgmDataFsl2HistoryLogTest {
+    @Test
+    public void testCgmDataFsl2HistoryLogParse() {
+        CgmDataFsl2HistoryLog expected = new CgmDataFsl2HistoryLog(
+                // long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp
+                566516808L, 506706L, 3, 1, 4, -61, 257, 566516805L, 566512000L
+        );
+
+        HistoryLog parsed = HistoryLogParser.parse(expected.getCargo());
+        assertTrue(parsed instanceof CgmDataFsl2HistoryLog);
+
+        CgmDataFsl2HistoryLog parsedRes = (CgmDataFsl2HistoryLog) parsed;
+        assertEquals(expected.getPumpTimeSec(), parsedRes.getPumpTimeSec());
+        assertEquals(expected.getSequenceNum(), parsedRes.getSequenceNum());
+        assertEquals(expected.getStatus(), parsedRes.getStatus());
+        assertEquals(expected.getType(), parsedRes.getType());
+        assertEquals(expected.getRate(), parsedRes.getRate());
+        assertEquals(expected.getRssi(), parsedRes.getRssi());
+        assertEquals(expected.getValue(), parsedRes.getValue());
+        assertEquals(expected.getTimestamp(), parsedRes.getTimestamp());
+        assertEquals(expected.getTransmitterTimestamp(), parsedRes.getTransmitterTimestamp());
+    }
+}

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl3HistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl3HistoryLogTest.java
@@ -1,0 +1,30 @@
+package com.jwoglom.pumpx2.pump.messages.response.historyLog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CgmDataFsl3HistoryLogTest {
+    @Test
+    public void testCgmDataFsl3HistoryLogParse() {
+        CgmDataFsl3HistoryLog expected = new CgmDataFsl3HistoryLog(
+                // long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp
+                566516507L, 506696L, 0, 1, 13, -59, 261, 566516504L, 566510000L
+        );
+
+        HistoryLog parsed = HistoryLogParser.parse(expected.getCargo());
+        assertTrue(parsed instanceof CgmDataFsl3HistoryLog);
+
+        CgmDataFsl3HistoryLog parsedRes = (CgmDataFsl3HistoryLog) parsed;
+        assertEquals(expected.getPumpTimeSec(), parsedRes.getPumpTimeSec());
+        assertEquals(expected.getSequenceNum(), parsedRes.getSequenceNum());
+        assertEquals(expected.getStatus(), parsedRes.getStatus());
+        assertEquals(expected.getType(), parsedRes.getType());
+        assertEquals(expected.getRate(), parsedRes.getRate());
+        assertEquals(expected.getRssi(), parsedRes.getRssi());
+        assertEquals(expected.getValue(), parsedRes.getValue());
+        assertEquals(expected.getTimestamp(), parsedRes.getTimestamp());
+        assertEquals(expected.getTransmitterTimestamp(), parsedRes.getTransmitterTimestamp());
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose and persist additional CGM fields (status, type, rate, rssi, value, timestamp, transmitterTimestamp) for FSL2 and FSL3 history logs so callers can read and construct complete CGM entries.
- Ensure the history log cargo is constructed with the correct two-byte opcode encoding and full payload for round-trip parsing and building.

### Description
- Added fields `status`, `type`, `rate`, `rssi`, `value`, `timestamp`, and `transmitterTimestamp` to `CgmDataFsl2HistoryLog` and `CgmDataFsl3HistoryLog`, populated by `parse` and set by new constructors. 
- Added overloaded `buildCargo` methods that include the new fields in the cargo and adjusted opcode byte encoding to use two little-endian bytes (e.g. `(byte)(372 & 0xFF), (byte)(372 >> 8)`).
- Added convenience constructors and public getters for all new fields, and updated the existing constructors to call the expanded `buildCargo`.
- Added unit tests `CgmDataFsl2HistoryLogTest` and `CgmDataFsl3HistoryLogTest` that build expected logs, parse their cargo via `HistoryLogParser.parse`, and assert all fields match.

### Testing
- Ran the new unit tests `CgmDataFsl2HistoryLogTest` and `CgmDataFsl3HistoryLogTest`, and both tests passed. 
- Ran the project's unit-test run including parsing round-trips for the two modified classes, and the suite passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d0e1d1e8832cbfd3d8895ac9964c)