### PR TITLE
Skip setNotify for absent CONTROL characteristics on older firmware

### DIFF
--- a/androidLib/src/main/java/com/jwoglom/pumpx2/pump/bluetooth/TandemBluetoothHandler.java
+++ b/androidLib/src/main/java/com/jwoglom/pumpx2/pump/bluetooth/TandemBluetoothHandler.java
@@ -200,17 +200,36 @@ public class TandemBluetoothHandler {
             peripheral.readCharacteristic(ServiceUUID.DIS_SERVICE_UUID, CharacteristicUUID.MANUFACTURER_NAME_CHARACTERISTIC_UUID);
             peripheral.readCharacteristic(ServiceUUID.DIS_SERVICE_UUID, CharacteristicUUID.MODEL_NUMBER_CHARACTERISTIC_UUID);
 
-            // Try to turn on notifications for other characteristics
+            // Try to turn on notifications for other characteristics.
+            // Older pump firmwares (e.g. tslim X2 moonlight v7.4) do not expose every UUID we
+            // expect (CONTROL/CONTROL_STREAM are absent). blessed-android's setNotify(uuid,uuid,..)
+            // overload returns false silently when the characteristic is missing — no callback is
+            // fired, so the entry would never be removed from remainingCharacteristicNotificationsInit
+            // and the CHARACTERISTIC_NOTIFICATIONS gate would deadlock. Pre-flight here and skip
+            // absent ones so initialization can complete on those firmwares.
             CharacteristicUUID.ENABLED_NOTIFICATIONS.forEach(uuid -> {
                 UUID serviceUUID = ServiceUUID.PUMP_SERVICE_UUID;
                 if (CharacteristicUUID.SERVICE_CHANGED_CHARACTERISTICS.equals(uuid)) {
                     serviceUUID = ServiceUUID.GENERIC_ATTRIBUTE_SERVICE_UUID;
+                }
+                if (peripheral.getCharacteristic(serviceUUID, uuid) == null) {
+                    Timber.w("Skipping setNotify for missing characteristic %s on this pump (firmware does not expose it)", CharacteristicUUID.which(uuid));
+                    synchronized (remainingCharacteristicNotificationsInit) {
+                        remainingCharacteristicNotificationsInit.remove(uuid);
+                        if (remainingCharacteristicNotificationsInit.isEmpty()) {
+                            remainingConnectionInitializationSteps.remove(ConnectionInitializationStep.CHARACTERISTIC_NOTIFICATIONS);
+                        }
+                    }
+                    return;
                 }
                 peripheral.setNotify(serviceUUID, uuid, true);
             });
 
             Timber.i("TandemBluetoothHandler: waiting for Bluetooth initialization callback");
             remainingConnectionInitializationSteps.remove(ConnectionInitializationStep.SERVICES_DISCOVERED);
+            // The pre-flight loop above may have already cleared CHARACTERISTIC_NOTIFICATIONS if
+            // every required UUID was either absent or already setNotify'd; recheck now so we don't
+            // wait forever on a callback that will never come.
             checkIfInitialPumpConnectionEstablished(peripheral);
         }
 


### PR DESCRIPTION
## Summary

Older t:slim X2 firmwares (e.g. `moonlight v7.4`, BLE API v2.1) do not expose the `CONTROL` or `CONTROL_STREAM` characteristics under the pump service. The current `setNotify(serviceUUID, uuid, true)` loop in `TandemBluetoothHandler` silently fails for these absent UUIDs (blessed-android's overload returns `false` and never fires `onNotificationStateUpdate`), so the entries are never removed from `remainingCharacteristicNotificationsInit` and the `CHARACTERISTIC_NOTIFICATIONS` gate deadlocks. From the user's perspective the pump pairs but then gets stuck — in controlX2 this surfaces as "stage 5 of 7" (see [controlX2#89](https://github.com/jwoglom/controlX2/issues/89)).

This change pre-flights each UUID via `peripheral.getCharacteristic` before calling `setNotify`. When a characteristic is absent, we log a warning and remove the UUID from the pending sets so initialization can proceed. The gate is rechecked after the loop in case every UUID was either absent or already dispatched.

## Empirical validation

Verified against a real-world `tslim X2 ***585` running `moonlight v7.4` (API v2.1):

```
W TandemBluetoothHandler: Skipping setNotify for missing characteristic CONTROL on this pump (firmware does not expose it)
W TandemBluetoothHandler: Skipping setNotify for missing characteristic CONTROL_STREAM on this pump (firmware does not expose it)
D TandemBluetoothHandler: TandemBluetoothHandler: initial pump connection is waiting for: [CONNECTION_UPDATED, MTU_UPDATED, CHARACTERISTIC_NOTIFICATIONS]
...
I TandemBluetoothHandler: TandemBluetoothHandler: initial pump connection established
I TandemPump: TandemPump: onInitialPumpConnection (1)
```

Pairing completes via the legacy 16-character `CentralChallengeRequest` flow, `ApiVersionResponse[majorVersion=2,minorVersion=1]` is read, and read-only queries (`HistoryLog`, `ControlIQIOB`, `InsulinStatus`, etc.) all return valid data. Remote-command opcodes still require API v2.5+ firmware (the pump simply doesn't expose that channel), but on older firmwares this turns a hard-fail pairing into a working read-only connection.

## Test plan
- [x] Manual: t:slim X2 `moonlight v7.4` (API v2.1) — pairing now completes; dashboard, CGM, IOB, history, battery all populate
- [x] Manual: confirmed via patched controlX2 build that the new warning log fires for `CONTROL` and `CONTROL_STREAM`, and the `CHARACTERISTIC_NOTIFICATIONS` gate clears
- [ ] Regression on a modern (API v3.5+) firmware where all characteristics are present — by inspection the pre-flight is a no-op when `getCharacteristic` returns non-null, but worth a sanity check on a current pump

🤖 Generated with [Claude Code](https://claude.com/claude-code)