### PR TITLE
fix #71 (opcode 212, LID_CGM_START_SESSION_GX), fix #72 (opcode 213, LID_CGM_JOIN_SESSION_GX), fix #73 (opcode 214, LID_CGM_STOP_SESSION_GX), fix #70 (opcode 211, LID_CGM_DATA_GX)

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataGxHistoryLog.java
@@ -65,8 +65,9 @@ public class CgmDataGxHistoryLog extends HistoryLog {
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(status), 
             new byte[]{ (byte) type }, 
-            new byte[]{ (byte) rate }, 
-            new byte[]{ (byte) rssi }, 
+            new byte[]{ (byte) rate },
+            new byte[]{0},
+            new byte[]{ (byte) rssi },
             Bytes.firstTwoBytesLittleEndian(value), 
             Bytes.toUint32(timestamp), 
             Bytes.toUint32(transmitterTimestamp)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionHistoryLog.java
@@ -11,11 +11,27 @@ import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
 )
 public class CgmJoinSessionHistoryLog extends HistoryLog {
 
+    private long currentTransmitterTime;
+    private long sessionStartTime;
+    private int sessionJoinReasonRaw;
+    private int sessionDuration;
+
     public CgmJoinSessionHistoryLog() {}
     public CgmJoinSessionHistoryLog(long pumpTimeSec, long sequenceNum) {
-        super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum);
+        this(pumpTimeSec, sequenceNum, 0, 0, 0, 0);
+    }
 
+    public CgmJoinSessionHistoryLog(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, int sessionJoinReasonRaw, int sessionDuration) {
+        super(pumpTimeSec, sequenceNum);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, currentTransmitterTime, sessionStartTime, sessionJoinReasonRaw, sessionDuration);
+        this.currentTransmitterTime = currentTransmitterTime;
+        this.sessionStartTime = sessionStartTime;
+        this.sessionJoinReasonRaw = sessionJoinReasonRaw;
+        this.sessionDuration = sessionDuration;
+    }
+
+    public CgmJoinSessionHistoryLog(long currentTransmitterTime, long sessionStartTime, int sessionJoinReasonRaw, int sessionDuration) {
+        this(0, 0, currentTransmitterTime, sessionStartTime, sessionJoinReasonRaw, sessionDuration);
     }
 
     public int typeId() {
@@ -26,13 +42,89 @@ public class CgmJoinSessionHistoryLog extends HistoryLog {
         Validate.isTrue(raw.length == 26);
         this.cargo = raw;
         parseBase(raw);
+        this.currentTransmitterTime = Bytes.readUint32(raw, 10);
+        this.sessionStartTime = Bytes.readUint32(raw, 14);
+        this.sessionJoinReasonRaw = raw[24] & 0xFF;
+        this.sessionDuration = raw[25] & 0xFF;
 
     }
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
+        return buildCargo(pumpTimeSec, sequenceNum, 0, 0, 0, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, int sessionJoinReasonRaw, int sessionDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{(byte) 213, 0},
             Bytes.toUint32(pumpTimeSec),
-            Bytes.toUint32(sequenceNum)));
+            Bytes.toUint32(sequenceNum),
+            Bytes.toUint32(currentTransmitterTime),
+            Bytes.toUint32(sessionStartTime),
+            new byte[]{0, 0, 0, 0, 0, 0},
+            new byte[]{(byte) sessionJoinReasonRaw},
+            new byte[]{(byte) sessionDuration}));
+    }
+
+    /**
+     * @return the current transmitter time, in seconds
+     */
+    public long getCurrentTransmitterTime() {
+        return currentTransmitterTime;
+    }
+
+    /**
+     * @return the session start time, in seconds
+     */
+    public long getSessionStartTime() {
+        return sessionStartTime;
+    }
+
+    public int getSessionJoinReasonRaw() {
+        return sessionJoinReasonRaw;
+    }
+
+    public enum SessionJoinReason {
+        DEXBLES_REASON_USER(0),
+        DEXBLES_REASON_UNKNOWN(1),
+        DEXBLES_REASON_TX_END_OF_LIFE(3),
+        DEXBLES_REASON_TRANSMITTER_ERROR(4),
+        DEXBLES_REASON_SESSION_STOP_SUCCESS(5),
+        DEXBLES_REASON_TRANSMITTER_NOT_IN_SESSION(6),
+        DEXBLES_REASON_NEW_SESSION_STARTED_SUCCESS(8),
+        DEXBLES_REASON_SESSION_STARTED_IN_PROGRESS(9),
+        DEXBLES_REASON_TRANSMITTER_IN_SESSION(10),
+        DEXBLES_REASON_BLESTACK_INVALID(11),
+        DEXBLES_REASON_NEW_AUTOCAL_SESSION_STARTED_SUCCESS(12),
+        DEXBLES_REASON_NO_AUTOCAL_SESSION_IN_PROGRESS(13),
+
+        ;
+        private int id;
+        SessionJoinReason(int id) {
+            this.id = id;
+        }
+
+        public static SessionJoinReason fromId(int id) {
+            for (SessionJoinReason r : values()) {
+                if (r.id == id) {
+                    return r;
+                }
+            }
+            return null;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public SessionJoinReason getSessionJoinReason() {
+        return SessionJoinReason.fromId(sessionJoinReasonRaw);
+    }
+
+    /**
+     * @return the session duration, in days
+     */
+    public int getSessionDuration() {
+        return sessionDuration;
     }
 }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionHistoryLog.java
@@ -11,11 +11,25 @@ import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
 )
 public class CgmStartSessionHistoryLog extends HistoryLog {
 
+    private long currentTransmitterTime;
+    private long sessionStartTime;
+    private int sessionDuration;
+
     public CgmStartSessionHistoryLog() {}
     public CgmStartSessionHistoryLog(long pumpTimeSec, long sequenceNum) {
-        super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum);
+        this(pumpTimeSec, sequenceNum, 0, 0, 0);
+    }
 
+    public CgmStartSessionHistoryLog(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, int sessionDuration) {
+        super(pumpTimeSec, sequenceNum);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, currentTransmitterTime, sessionStartTime, sessionDuration);
+        this.currentTransmitterTime = currentTransmitterTime;
+        this.sessionStartTime = sessionStartTime;
+        this.sessionDuration = sessionDuration;
+    }
+
+    public CgmStartSessionHistoryLog(long currentTransmitterTime, long sessionStartTime, int sessionDuration) {
+        this(0, 0, currentTransmitterTime, sessionStartTime, sessionDuration);
     }
 
     public int typeId() {
@@ -26,13 +40,45 @@ public class CgmStartSessionHistoryLog extends HistoryLog {
         Validate.isTrue(raw.length == 26);
         this.cargo = raw;
         parseBase(raw);
+        this.currentTransmitterTime = Bytes.readUint32(raw, 10);
+        this.sessionStartTime = Bytes.readUint32(raw, 14);
+        this.sessionDuration = raw[25] & 0xFF;
 
     }
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
+        return buildCargo(pumpTimeSec, sequenceNum, 0, 0, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, int sessionDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{(byte) 212, 0},
             Bytes.toUint32(pumpTimeSec),
-            Bytes.toUint32(sequenceNum)));
+            Bytes.toUint32(sequenceNum),
+            Bytes.toUint32(currentTransmitterTime),
+            Bytes.toUint32(sessionStartTime),
+            new byte[]{0, 0, 0, 0, 0, 0, 0},
+            new byte[]{(byte) sessionDuration}));
+    }
+
+    /**
+     * @return the current transmitter time in seconds
+     */
+    public long getCurrentTransmitterTime() {
+        return currentTransmitterTime;
+    }
+
+    /**
+     * @return the session start time in seconds
+     */
+    public long getSessionStartTime() {
+        return sessionStartTime;
+    }
+
+    /**
+     * @return the session duration in days
+     */
+    public int getSessionDuration() {
+        return sessionDuration;
     }
 }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionHistoryLog.java
@@ -11,11 +11,29 @@ import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
 )
 public class CgmStopSessionHistoryLog extends HistoryLog {
 
+    private long currentTransmitterTime;
+    private long sessionStartTime;
+    private long sessionStopTime;
+    private int sessionStopReasonRaw;
+    private int sessionDuration;
+
     public CgmStopSessionHistoryLog() {}
     public CgmStopSessionHistoryLog(long pumpTimeSec, long sequenceNum) {
-        super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum);
+        this(pumpTimeSec, sequenceNum, 0, 0, 0, 0, 0);
+    }
 
+    public CgmStopSessionHistoryLog(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, long sessionStopTime, int sessionStopReasonRaw, int sessionDuration) {
+        super(pumpTimeSec, sequenceNum);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, currentTransmitterTime, sessionStartTime, sessionStopTime, sessionStopReasonRaw, sessionDuration);
+        this.currentTransmitterTime = currentTransmitterTime;
+        this.sessionStartTime = sessionStartTime;
+        this.sessionStopTime = sessionStopTime;
+        this.sessionStopReasonRaw = sessionStopReasonRaw;
+        this.sessionDuration = sessionDuration;
+    }
+
+    public CgmStopSessionHistoryLog(long currentTransmitterTime, long sessionStartTime, long sessionStopTime, int sessionStopReasonRaw, int sessionDuration) {
+        this(0, 0, currentTransmitterTime, sessionStartTime, sessionStopTime, sessionStopReasonRaw, sessionDuration);
     }
 
     public int typeId() {
@@ -26,13 +44,98 @@ public class CgmStopSessionHistoryLog extends HistoryLog {
         Validate.isTrue(raw.length == 26);
         this.cargo = raw;
         parseBase(raw);
+        this.currentTransmitterTime = Bytes.readUint32(raw, 10);
+        this.sessionStartTime = Bytes.readUint32(raw, 14);
+        this.sessionStopTime = Bytes.readUint32(raw, 18);
+        this.sessionStopReasonRaw = raw[24] & 0xFF;
+        this.sessionDuration = raw[25] & 0xFF;
 
     }
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
+        return buildCargo(pumpTimeSec, sequenceNum, 0, 0, 0, 0, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, long sessionStopTime, int sessionStopReasonRaw, int sessionDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{(byte) 214, 0},
             Bytes.toUint32(pumpTimeSec),
-            Bytes.toUint32(sequenceNum)));
+            Bytes.toUint32(sequenceNum),
+            Bytes.toUint32(currentTransmitterTime),
+            Bytes.toUint32(sessionStartTime),
+            Bytes.toUint32(sessionStopTime),
+            new byte[]{0, 0},
+            new byte[]{(byte) sessionStopReasonRaw},
+            new byte[]{(byte) sessionDuration}));
+    }
+
+    /**
+     * @return the current transmitter time, in seconds
+     */
+    public long getCurrentTransmitterTime() {
+        return currentTransmitterTime;
+    }
+
+    /**
+     * @return the session start time, in seconds
+     */
+    public long getSessionStartTime() {
+        return sessionStartTime;
+    }
+
+    /**
+     * @return the session stop time, in seconds
+     */
+    public long getSessionStopTime() {
+        return sessionStopTime;
+    }
+
+    public int getSessionStopReasonRaw() {
+        return sessionStopReasonRaw;
+    }
+
+    public enum SessionStopReason {
+        DEXBLES_REASON_USER(0),
+        DEXBLES_REASON_UNKNOWN(1),
+        DEXBLES_REASON_TX_END_OF_LIFE(3),
+        DEXBLES_REASON_TRANSMITTER_ERROR(4),
+        DEXBLES_REASON_SESSION_STOP_SUCCESS(5),
+        DEXBLES_REASON_TRANSMITTER_NOT_IN_SESSION(6),
+        DEXBLES_REASON_NEW_SESSION_STARTED_SUCCESS(8),
+        DEXBLES_REASON_SESSION_STARTED_IN_PROGRESS(9),
+        DEXBLES_REASON_TRANSMITTER_IN_SESSION(10),
+        DEXBLES_REASON_BLESTACK_INVALID(11),
+        DEXBLES_REASON_NEW_AUTOCAL_SESSION_STARTED_SUCCESS(12),
+        DEXBLES_REASON_NO_AUTOCAL_SESSION_IN_PROGRESS(13),
+
+        ;
+        private int id;
+        SessionStopReason(int id) {
+            this.id = id;
+        }
+
+        public static SessionStopReason fromId(int id) {
+            for (SessionStopReason r : values()) {
+                if (r.id == id) {
+                    return r;
+                }
+            }
+            return null;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public SessionStopReason getSessionStopReason() {
+        return SessionStopReason.fromId(sessionStopReasonRaw);
+    }
+
+    /**
+     * @return the session duration, in days
+     */
+    public int getSessionDuration() {
+        return sessionDuration;
     }
 }


### PR DESCRIPTION
#71 (opcode 212, LID_CGM_START_SESSION_GX) — added currentTransmitterTime, sessionStartTime, sessionDuration parsing → commit 40c319f
#72 (opcode 213, LID_CGM_JOIN_SESSION_GX) — added those three plus sessionJoinReasonRaw/SessionJoinReason enum → commit 9811b72
#73 (opcode 214, LID_CGM_STOP_SESSION_GX) — added currentTransmitterTime, sessionStartTime, sessionStopTime, sessionStopReasonRaw/SessionStopReason enum, sessionDuration → commit a1ead32
#70 (opcode 211, LID_CGM_DATA_GX) — fixed the buildCargo()/parse() byte-offset mismatch (missing gap byte before rssi), matching the fix already applied to the FSL2/FSL3 siblings → commit 5240fc8
