### PR TITLE
Fix #37 (opCode 4, AlertActivatedHistoryLog), Fix #38 (opCode 5, AlarmActivatedHistoryLog), Fix #44 (AlertResponseType)

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/AlertStatusResponse.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/AlertStatusResponse.java
@@ -115,7 +115,7 @@ public class AlertStatusResponse extends NotificationMessage {
         CGM_UNAVAILABLE(48, "The CGM is unavailable due to a problem with the sensor."),
         FILL_TUBING_STILL_IN_PROGRESS(49, "The fill tubing process is still in progress and was not completed."),
         DEFAULT_ALERT_50(50),
-        DEFAULT_ALERT_51(51),
+        CONTROL_IQ_LOW(51, "Control-IQ has reduced basal insulin delivery due to a low or predicted low glucose value."),
         DEFAULT_ALERT_52(52),
         DEFAULT_ALERT_53(53),
         DEVICE_PAIRED(54, "The pump was paired successfully to a Bluetooth device."),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmActivatedHistoryLog.java
@@ -14,15 +14,28 @@ import java.math.BigInteger;
     usedByTidepool = true
 )
 public class AlarmActivatedHistoryLog extends HistoryLog {
-    
+
     private long alarmId;
-    
+    private long faultLocatorData;
+    private long param1;
+    private float param2;
+
     public AlarmActivatedHistoryLog() {}
-    public AlarmActivatedHistoryLog(long pumpTimeSec, long sequenceNum, long alarmId) {
+    public AlarmActivatedHistoryLog(long pumpTimeSec, long sequenceNum, long alarmId, long faultLocatorData, long param1, float param2) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, alarmId);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, alarmId, faultLocatorData, param1, param2);
         this.alarmId = alarmId;
-        
+        this.faultLocatorData = faultLocatorData;
+        this.param1 = param1;
+        this.param2 = param2;
+    }
+
+    public AlarmActivatedHistoryLog(long alarmId, long faultLocatorData, long param1, float param2) {
+        this(0, 0, alarmId, faultLocatorData, param1, param2);
+    }
+
+    public AlarmActivatedHistoryLog(long pumpTimeSec, long sequenceNum, long alarmId) {
+        this(pumpTimeSec, sequenceNum, alarmId, 0, 0, 0f);
     }
 
     public AlarmActivatedHistoryLog(long alarmId) {
@@ -38,18 +51,40 @@ public class AlarmActivatedHistoryLog extends HistoryLog {
         this.cargo = raw;
         parseBase(raw);
         this.alarmId = Bytes.readUint32(raw, 10);
-        
+        this.faultLocatorData = Bytes.readUint32(raw, 14);
+        this.param1 = Bytes.readUint32(raw, 18);
+        this.param2 = Bytes.readFloat(raw, 22);
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alarmId) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alarmId, long faultLocatorData, long param1, float param2) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{5, 0},
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            Bytes.toUint32(alarmId)));
+            Bytes.toUint32(alarmId),
+            Bytes.toUint32(faultLocatorData),
+            Bytes.toUint32(param1),
+            Bytes.toFloat(param2)));
     }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alarmId) {
+        return buildCargo(pumpTimeSec, sequenceNum, alarmId, 0, 0, 0f);
+    }
+
     public long getAlarmId() {
         return alarmId;
+    }
+
+    public long getFaultLocatorData() {
+        return faultLocatorData;
+    }
+
+    public long getParam1() {
+        return param1;
+    }
+
+    public float getParam2() {
+        return param2;
     }
 
     /**

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLog.java
@@ -14,15 +14,28 @@ import java.math.BigInteger;
     usedByTidepool = true
 )
 public class AlertActivatedHistoryLog extends HistoryLog {
-    
+
     private long alertId;
-    
+    private long faultLocatorData;
+    private long param1;
+    private float param2;
+
     public AlertActivatedHistoryLog() {}
-    public AlertActivatedHistoryLog(long pumpTimeSec, long sequenceNum, long alertId) {
+    public AlertActivatedHistoryLog(long pumpTimeSec, long sequenceNum, long alertId, long faultLocatorData, long param1, float param2) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, alertId);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, alertId, faultLocatorData, param1, param2);
         this.alertId = alertId;
-        
+        this.faultLocatorData = faultLocatorData;
+        this.param1 = param1;
+        this.param2 = param2;
+    }
+
+    public AlertActivatedHistoryLog(long alertId, long faultLocatorData, long param1, float param2) {
+        this(0, 0, alertId, faultLocatorData, param1, param2);
+    }
+
+    public AlertActivatedHistoryLog(long pumpTimeSec, long sequenceNum, long alertId) {
+        this(pumpTimeSec, sequenceNum, alertId, 0, 0, 0f);
     }
 
     public AlertActivatedHistoryLog(long alertId) {
@@ -38,19 +51,40 @@ public class AlertActivatedHistoryLog extends HistoryLog {
         this.cargo = raw;
         parseBase(raw);
         this.alertId = Bytes.readUint32(raw, 10);
-        // other unknown fields
-        
+        this.faultLocatorData = Bytes.readUint32(raw, 14);
+        this.param1 = Bytes.readUint32(raw, 18);
+        this.param2 = Bytes.readFloat(raw, 22);
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId, long faultLocatorData, long param1, float param2) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{4, 0},
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            Bytes.toUint32(alertId)));
+            Bytes.toUint32(alertId),
+            Bytes.toUint32(faultLocatorData),
+            Bytes.toUint32(param1),
+            Bytes.toFloat(param2)));
     }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
+        return buildCargo(pumpTimeSec, sequenceNum, alertId, 0, 0, 0f);
+    }
+
     public long getAlertId() {
         return alertId;
+    }
+
+    public long getFaultLocatorData() {
+        return faultLocatorData;
+    }
+
+    public long getParam1() {
+        return param1;
+    }
+
+    public float getParam2() {
+        return param2;
     }
 
     /**
@@ -59,5 +93,5 @@ public class AlertActivatedHistoryLog extends HistoryLog {
     public AlertStatusResponse.AlertResponseType getAlertResponseType() {
         return AlertStatusResponse.AlertResponseType.fromSingularId(alertId);
     }
-    
+
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmActivatedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmActivatedHistoryLogTest.java
@@ -17,8 +17,8 @@ public class AlarmActivatedHistoryLogTest {
     @Test
     public void testAlarmActivatedHistoryLog1() throws DecoderException {
         AlarmActivatedHistoryLog expected = new AlarmActivatedHistoryLog(
-            // long alarmId
-                18
+            // long alarmId, long faultLocatorData, long param1, float param2
+                18, 8311, 6544514, 0.0f
         );
 
         AlarmActivatedHistoryLog parsedRes = (AlarmActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -31,8 +31,8 @@ public class AlarmActivatedHistoryLogTest {
     @Test
     public void testAlarmActivatedHistoryLog2() throws DecoderException {
         AlarmActivatedHistoryLog expected = new AlarmActivatedHistoryLog(
-                // long alarmId
-                23
+                // long alarmId, long faultLocatorData, long param1, float param2
+                23, 8311, 18, 0.0f
         );
 
         AlarmActivatedHistoryLog parsedRes = (AlarmActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -45,8 +45,8 @@ public class AlarmActivatedHistoryLogTest {
     @Test
     public void testAlarmActivatedHistoryLog3() throws DecoderException {
         AlarmActivatedHistoryLog expected = new AlarmActivatedHistoryLog(
-                // long alarmId
-                23
+                // long alarmId, long faultLocatorData, long param1, float param2
+                23, 8311, 18, 0.0f
         );
 
         AlarmActivatedHistoryLog parsedRes = (AlarmActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -59,8 +59,8 @@ public class AlarmActivatedHistoryLogTest {
     @Test
     public void testAlarmActivatedHistoryLog4() throws DecoderException {
         AlarmActivatedHistoryLog expected = new AlarmActivatedHistoryLog(
-                // long alarmId
-                18
+                // long alarmId, long faultLocatorData, long param1, float param2
+                18, 8311, 6633487, 0.0f
         );
 
         AlarmActivatedHistoryLog parsedRes = (AlarmActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLogTest.java
@@ -17,8 +17,8 @@ public class AlertActivatedHistoryLogTest {
     @Test
     public void testAlertActivatedHistoryLog1() throws DecoderException {
         AlertActivatedHistoryLog expected = new AlertActivatedHistoryLog(
-            // long alertId
-                51
+            // long alertId, long faultLocatorData, long param1, float param2
+                51, 0, 0, 514.0f
         );
 
         AlertActivatedHistoryLog parsedRes = (AlertActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -31,8 +31,8 @@ public class AlertActivatedHistoryLogTest {
     @Test
     public void testAlertActivatedHistoryLog2() throws DecoderException {
         AlertActivatedHistoryLog expected = new AlertActivatedHistoryLog(
-                // long alertId
-                48
+                // long alertId, long faultLocatorData, long param1, float param2
+                48, 8623, 0, 0.0f
         );
 
         AlertActivatedHistoryLog parsedRes = (AlertActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -45,8 +45,8 @@ public class AlertActivatedHistoryLogTest {
     @Test
     public void testAlertActivatedHistoryLog3() throws DecoderException {
         AlertActivatedHistoryLog expected = new AlertActivatedHistoryLog(
-                // long alertId
-                11
+                // long alertId, long faultLocatorData, long param1, float param2
+                11, 8378, 0, 0.0f
         );
 
         AlertActivatedHistoryLog parsedRes = (AlertActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -59,8 +59,8 @@ public class AlertActivatedHistoryLogTest {
     @Test
     public void testAlertActivatedHistoryLog4() throws DecoderException {
         AlertActivatedHistoryLog expected = new AlertActivatedHistoryLog(
-                // long alertId
-                0
+                // long alertId, long faultLocatorData, long param1, float param2
+                0, 8242, 102, 347.551513671875f
         );
 
         AlertActivatedHistoryLog parsedRes = (AlertActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLogTest.java
@@ -25,7 +25,7 @@ public class AlertActivatedHistoryLogTest {
                 "040024c0981aadde020033000000000000000000000000800044",
                 expected
         );
-        assertEquals(AlertStatusResponse.AlertResponseType.DEFAULT_ALERT_51, parsedRes.getAlertResponseType());
+        assertEquals(AlertStatusResponse.AlertResponseType.CONTROL_IQ_LOW, parsedRes.getAlertResponseType());
     }
 
     @Test


### PR DESCRIPTION
Fix #37 (opCode 4, AlertActivatedHistoryLog): added faultLocatorData/param1/param2 fields at offsets 14/18/22, updated tests. Commit 99b0656.
Fix #38 (opCode 5, AlarmActivatedHistoryLog): same three fields added, tests updated. Commit cddebd8.
Fix #44 (AlertResponseType): code 51 renamed from placeholder DEFAULT_ALERT_51 to CONTROL_IQ_LOW with a description; code 49 was already correctly named FILL_TUBING_STILL_IN_PROGRESS, so no change needed there. Commit 2c12783.