### PR TITLE
Fix jar/shadow jar build

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You may need to re-open the app, clear app data, and/or unpair and re-pair the d
 * `com.github.jwoglom.pumpX2:pumpx2-android`
 * `com.github.jwoglom.pumpX2:pumpx2-messages`
 * `com.github.jwoglom.pumpX2:pumpx2-shared`
+* `com.github.jwoglom.pumpX2:pumpx2-cliparser` (a runnable, executable jar with all dependencies bundled)
 
 For example, using Gradle, first add the JitPack repositories to your root project `settings.gradle`:
 ```

--- a/cliparser/build.gradle
+++ b/cliparser/build.gradle
@@ -11,6 +11,12 @@ ext {
     javaMainClass = "com.jwoglom.pumpx2.cliparser.Main"
 }
 
+// The plain jar isn't runnable on its own (no bundled dependencies), so disable
+// it to avoid colliding with shadowJar's output, which uses the same classifier.
+tasks.jar {
+    enabled = false
+}
+
 shadowJar {
     archiveBaseName.set('cliparser')
     archiveClassifier.set('')
@@ -30,7 +36,7 @@ publishing {
             artifactId "pumpx2-cliparser"
             groupId rootProject.group
             version rootProject.version
-            from components.java
+            from components.shadow
             pom {
                 name = "PumpX2 CLIParser"
                 description = "A sample CLI tool which uses the PumpX2 Java library to parse and decode t:slim X2 insulin pump message byte streams."
@@ -57,12 +63,6 @@ publishing {
         }
     }
 }
-
-// ensure built JAR is executable
-tasks.jar {
-    manifest.attributes["Main-Class"] = javaMainClass
-}
-
 
 dependencies {
     implementation project(':shared')


### PR DESCRIPTION
cliparser/build.gradle had both jar and shadowJar writing to the same output filename, so the published artifact only happened to be the runnable fat jar because shadowJar incidentally ran after jar. Fixed by disabling the (useless, non-runnable) plain jar task and publishing components.shadow explicitly, per Gradle Shadow plugin's documented pattern. Verified locally with the system Gradle 9.2.1 — build succeeds, only shadowJar runs now, and the published jar is correct.