### PR TITLE
Fix opCode 11/12 history log parsing and cargo serialization

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLog.java
@@ -13,19 +13,21 @@ import java.math.BigInteger;
     usedByTidepool = true
 )
 public class PumpingResumedHistoryLog extends HistoryLog {
-    
+
+    private long preResumeState;
     private int insulinAmount;
-    
+
     public PumpingResumedHistoryLog() {}
-    public PumpingResumedHistoryLog(long pumpTimeSec, long sequenceNum, int insulinAmount) {
+    public PumpingResumedHistoryLog(long pumpTimeSec, long sequenceNum, long preResumeState, int insulinAmount) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, insulinAmount);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, preResumeState, insulinAmount);
+        this.preResumeState = preResumeState;
         this.insulinAmount = insulinAmount;
-        
+
     }
 
-    public PumpingResumedHistoryLog(int insulinAmount) {
-        this(0, 0, insulinAmount);
+    public PumpingResumedHistoryLog(long preResumeState, int insulinAmount) {
+        this(0, 0, preResumeState, insulinAmount);
     }
 
     public int typeId() {
@@ -36,24 +38,43 @@ public class PumpingResumedHistoryLog extends HistoryLog {
         Validate.isTrue(raw.length == 26);
         this.cargo = raw;
         parseBase(raw);
+        this.preResumeState = Bytes.readUint32(raw, 10);
         this.insulinAmount = Bytes.readShort(raw, 14);
-        
+
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int insulinAmount) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long preResumeState, int insulinAmount) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{12, 0},
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            new byte[4], // unknown -- uint32(100)
+            Bytes.toUint32(preResumeState),
             Bytes.firstTwoBytesLittleEndian(insulinAmount)));
     }
 
     /**
-     * @return the insulin amount at the time pumping was resumed (most likely the IOB, needs confirmation)
+     * @return the state of the pump immediately before pumping was resumed
+     * (Tandem's pump-logs JSON calls this property preResumeState)
+     */
+    public long getPreResumeState() {
+        return preResumeState;
+    }
+
+    /**
+     * @return an insulin reservoir quantity, in whole units, at the time pumping was resumed.
+     * This is NOT the IOB: the value is byte-identical in the paired suspended and resumed
+     * records which bracket a suspension, while the IOB the pump reports in LID_DAILY_BASAL
+     * over the same window decays.
+     *
+     * TODO: determine whether this is the insulin remaining in the reservoir or the current
+     * cartridge fill level. Observed captures support both readings and the question is
+     * unresolved: one suspend/resume pair drops 120 -> 105 across a 15 minute suspension
+     * (consistent with remaining volume being consumed by a tubing prime), while another
+     * capture reads 180 at a suspend roughly ten hours after a 180 unit cartridge fill
+     * (which remaining volume should have decremented by then).
      */
     public int getInsulinAmount() {
         return insulinAmount;
     }
-    
+
 }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLog.java
@@ -11,21 +11,25 @@ import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
     usedByTidepool = true
 )
 public class PumpingSuspendedHistoryLog extends HistoryLog {
-    
+
+    private long preSuspendState;
     private int insulinAmount;
     private int reasonId;
-    
+    private int rpaTimeout;
+
     public PumpingSuspendedHistoryLog() {}
-    public PumpingSuspendedHistoryLog(long pumpTimeSec, long sequenceNum, int insulinAmount, int reasonId) {
+    public PumpingSuspendedHistoryLog(long pumpTimeSec, long sequenceNum, long preSuspendState, int insulinAmount, int reasonId, int rpaTimeout) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, insulinAmount, reasonId);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, preSuspendState, insulinAmount, reasonId, rpaTimeout);
+        this.preSuspendState = preSuspendState;
         this.insulinAmount = insulinAmount;
         this.reasonId = reasonId;
-        
+        this.rpaTimeout = rpaTimeout;
+
     }
 
-    public PumpingSuspendedHistoryLog(int insulinAmount, int reasonId) {
-        this(0, 0, insulinAmount, reasonId);
+    public PumpingSuspendedHistoryLog(long preSuspendState, int insulinAmount, int reasonId, int rpaTimeout) {
+        this(0, 0, preSuspendState, insulinAmount, reasonId, rpaTimeout);
     }
 
     public int typeId() {
@@ -36,23 +40,43 @@ public class PumpingSuspendedHistoryLog extends HistoryLog {
         Validate.isTrue(raw.length == 26);
         this.cargo = raw;
         parseBase(raw);
+        this.preSuspendState = Bytes.readUint32(raw, 10);
         this.insulinAmount = Bytes.readShort(raw, 14);
         this.reasonId = raw[16];
-        
+        this.rpaTimeout = raw[17];
+
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int insulinAmount, int reason) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long preSuspendState, int insulinAmount, int reason, int rpaTimeout) {
         return HistoryLog.fillCargo(Bytes.combine(
             new byte[]{11, 0},
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            Bytes.firstTwoBytesLittleEndian(insulinAmount), 
-            new byte[]{ (byte) reason }));
+            Bytes.toUint32(preSuspendState),
+            Bytes.firstTwoBytesLittleEndian(insulinAmount),
+            new byte[]{ (byte) reason, (byte) rpaTimeout }));
     }
 
     /**
-     * @return insulin amount in milliunits at the time pumping was suspended (I think this matches
-     * with the IOB, needs confirmation)
+     * @return the state of the pump immediately before pumping was suspended
+     * (Tandem's pump-logs JSON calls this property preSuspendState)
+     */
+    public long getPreSuspendState() {
+        return preSuspendState;
+    }
+
+    /**
+     * @return an insulin reservoir quantity, in whole units, at the time pumping was suspended.
+     * This is NOT the IOB: the value is byte-identical in the paired suspended and resumed
+     * records which bracket a suspension, while the IOB the pump reports in LID_DAILY_BASAL
+     * over the same window decays.
+     *
+     * TODO: determine whether this is the insulin remaining in the reservoir or the current
+     * cartridge fill level. Observed captures support both readings and the question is
+     * unresolved: one suspend/resume pair drops 120 -> 105 across a 15 minute suspension
+     * (consistent with remaining volume being consumed by a tubing prime), while another
+     * capture reads 180 at a suspend roughly ten hours after a 180 unit cartridge fill
+     * (which remaining volume should have decremented by then).
      */
     public int getInsulinAmount() {
         return insulinAmount;
@@ -62,6 +86,15 @@ public class PumpingSuspendedHistoryLog extends HistoryLog {
     }
     public SuspendReason getReason() {
         return SuspendReason.fromId(reasonId);
+    }
+
+    /**
+     * @return the resume pump alert (RPA) timeout in minutes: how long the pump waits while
+     * suspended before alerting that insulin delivery is still stopped. 0 when unset.
+     * (Tandem's pump-logs JSON calls this property rpaTimeout)
+     */
+    public int getRpaTimeout() {
+        return rpaTimeout;
     }
 
     public enum SuspendReason {
@@ -85,5 +118,5 @@ public class PumpingSuspendedHistoryLog extends HistoryLog {
             return null;
         }
     }
-    
+
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLogTest.java
@@ -1,20 +1,62 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+import static com.jwoglom.pumpx2.pump.messages.response.historyLog.PumpingSuspendedHistoryLogTest.withoutSourceNibble;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
 public class PumpingResumedHistoryLogTest {
     @Test
     public void testPumpingResumedHistoryLog() throws DecoderException {
-        // 0.180u
         PumpingResumedHistoryLog expected = new PumpingResumedHistoryLog(
-            // int insulinAmount
-                180
+            // long preResumeState, int insulinAmount
+                100, 180
         );
 
         PumpingResumedHistoryLog parsedRes = (PumpingResumedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
                 "0c005fea951aa4c9020064000000b40000000000000000000000",
                 expected
         );
+        assertEquals(100L, parsedRes.getPreResumeState());
+        assertEquals(180, parsedRes.getInsulinAmount());
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
+    @Test
+    public void testPumpingResumedHistoryLogAfterAlarmSuspend() throws DecoderException {
+        PumpingResumedHistoryLog expected = new PumpingResumedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preResumeState, int insulinAmount
+                587315910L, 744340L, 100, 150
+        );
+
+        PumpingResumedHistoryLog parsedRes = (PumpingResumedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0c10c6ba0123945b0b0064000000960000000000000000000000",
+                expected
+        );
+        assertEquals(587315910L, parsedRes.getPumpTimeSec());
+        assertEquals(744340L, parsedRes.getSequenceNum());
+        assertEquals(100L, parsedRes.getPreResumeState());
+        assertEquals(150, parsedRes.getInsulinAmount());
+        assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
+    }
+
+    @Test
+    public void testPumpingResumedHistoryLogAfterUserSuspend() throws DecoderException {
+        PumpingResumedHistoryLog expected = new PumpingResumedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preResumeState, int insulinAmount
+                587388971L, 748806L, 100, 105
+        );
+
+        PumpingResumedHistoryLog parsedRes = (PumpingResumedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0c102bd80223066d0b0064000000690000000000000000000000",
+                expected
+        );
+        assertEquals(587388971L, parsedRes.getPumpTimeSec());
+        assertEquals(748806L, parsedRes.getSequenceNum());
+        assertEquals(100L, parsedRes.getPreResumeState());
+        assertEquals(105, parsedRes.getInsulinAmount());
+        assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLogTest.java
@@ -9,10 +9,9 @@ import org.junit.Test;
 public class PumpingSuspendedHistoryLogTest {
     @Test
     public void testPumpingSuspendedHistoryLog1() throws DecoderException {
-        // 0.031 IOB
         PumpingSuspendedHistoryLog expected = new PumpingSuspendedHistoryLog(
-            // int insulinAmount, int reason
-                31, 0
+            // long preSuspendState, int insulinAmount, int reason, int rpaTimeout
+                106, 31, 0, 0
         );
 
         PumpingSuspendedHistoryLog parsedRes = (PumpingSuspendedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -20,14 +19,14 @@ public class PumpingSuspendedHistoryLogTest {
                 expected
         );
         assertEquals(PumpingSuspendedHistoryLog.SuspendReason.USER_ABORTED, parsedRes.getReason());
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testPumpingSuspendedHistoryLog2() throws DecoderException {
-        // 0.180u IOB
         PumpingSuspendedHistoryLog expected = new PumpingSuspendedHistoryLog(
-                // int insulinAmount, int reason
-                180, 0
+                // long preSuspendState, int insulinAmount, int reason, int rpaTimeout
+                106, 180, 0, 0
         );
 
         PumpingSuspendedHistoryLog parsedRes = (PumpingSuspendedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -35,14 +34,14 @@ public class PumpingSuspendedHistoryLogTest {
                 expected
         );
         assertEquals(PumpingSuspendedHistoryLog.SuspendReason.USER_ABORTED, parsedRes.getReason());
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testPumpingSuspendedHistoryLog3() throws DecoderException {
-        // 0.180u IOB
         PumpingSuspendedHistoryLog expected = new PumpingSuspendedHistoryLog(
-                // int insulinAmount, int reason
-                180, 0
+                // long preSuspendState, int insulinAmount, int reason, int rpaTimeout
+                106, 180, 0, 0
         );
 
         PumpingSuspendedHistoryLog parsedRes = (PumpingSuspendedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
@@ -50,5 +49,57 @@ public class PumpingSuspendedHistoryLogTest {
                 expected
         );
         assertEquals(PumpingSuspendedHistoryLog.SuspendReason.USER_ABORTED, parsedRes.getReason());
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
+    @Test
+    public void testPumpingSuspendedHistoryLogAlarmReasonWithRpaTimeout() throws DecoderException {
+        PumpingSuspendedHistoryLog expected = new PumpingSuspendedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preSuspendState, int insulinAmount, int reason, int rpaTimeout
+                587315465L, 744310L, 106, 150, 1, 15
+        );
+
+        PumpingSuspendedHistoryLog parsedRes = (PumpingSuspendedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0b1009b90123765b0b006a0000009600010f0000000000000000",
+                expected
+        );
+        assertEquals(587315465L, parsedRes.getPumpTimeSec());
+        assertEquals(744310L, parsedRes.getSequenceNum());
+        assertEquals(106L, parsedRes.getPreSuspendState());
+        assertEquals(150, parsedRes.getInsulinAmount());
+        assertEquals(PumpingSuspendedHistoryLog.SuspendReason.ALARM, parsedRes.getReason());
+        assertEquals(15, parsedRes.getRpaTimeout());
+        assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
+    }
+
+    @Test
+    public void testPumpingSuspendedHistoryLogUserAbortedWithRpaTimeout() throws DecoderException {
+        PumpingSuspendedHistoryLog expected = new PumpingSuspendedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preSuspendState, int insulinAmount, int reason, int rpaTimeout
+                587387440L, 748755L, 106, 105, 0, 15
+        );
+
+        PumpingSuspendedHistoryLog parsedRes = (PumpingSuspendedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0b1030d20223d36c0b006a0000006900000f0000000000000000",
+                expected
+        );
+        assertEquals(587387440L, parsedRes.getPumpTimeSec());
+        assertEquals(748755L, parsedRes.getSequenceNum());
+        assertEquals(106L, parsedRes.getPreSuspendState());
+        assertEquals(105, parsedRes.getInsulinAmount());
+        assertEquals(PumpingSuspendedHistoryLog.SuspendReason.USER_ABORTED, parsedRes.getReason());
+        assertEquals(15, parsedRes.getRpaTimeout());
+        assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
+    }
+
+    /**
+     * The upper nibble of the second typeId byte identifies the source of the log entry and is
+     * not part of the typeId itself (parseBase masks it off with & 4095). buildCargo() has no
+     * source to emit, so it is masked out of the parsed cargo before comparing the two.
+     */
+    static byte[] withoutSourceNibble(byte[] cargo) {
+        byte[] out = cargo.clone();
+        out[1] = (byte) (out[1] & 0x0F);
+        return out;
     }
 }


### PR DESCRIPTION
PumpingSuspendedHistoryLog.buildCargo() did not round-trip its own parse(): it emitted insulinAmount at offset 10-11 and reason at 12, while parse() reads them at 14 and 16. Rewrite buildCargo() to emit the real record layout and add the two fields that were never parsed.

https://github.com/jwoglom/pumpX2/issues/39
https://github.com/jwoglom/pumpX2/issues/40