### PR TITLE
Fix bolus history log serialization, dispatch and field semantics

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusActivatedHistoryLog.java
@@ -23,9 +23,9 @@ public class BolusActivatedHistoryLog extends HistoryLog {
         this(pumpTimeSec, sequenceNum, bolusId, selectedIob, iob, bolusSize, 0);
     }
 
-    public BolusActivatedHistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int logGeneration) {
+    public BolusActivatedHistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int headerHighNibble) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, selectedIob, iob, bolusSize, logGeneration);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, selectedIob, iob, bolusSize, headerHighNibble);
         this.bolusId = bolusId;
         this.selectedIob = selectedIob;
         this.iob = iob;
@@ -69,9 +69,9 @@ public class BolusActivatedHistoryLog extends HistoryLog {
         return buildCargo(pumpTimeSec, sequenceNum, bolusId, selectedIob, iob, bolusSize, 0);
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int logGeneration) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int headerHighNibble) {
         return HistoryLog.fillCargo(Bytes.combine(
-            HistoryLog.typeIdBytes(55, logGeneration),
+            HistoryLog.typeIdBytes(55, headerHighNibble),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusActivatedHistoryLog.java
@@ -4,8 +4,6 @@ import org.apache.commons.lang3.Validate;
 import com.jwoglom.pumpx2.pump.messages.annotations.HistoryLogProps;
 import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
 
-import java.math.BigInteger;
-
 @HistoryLogProps(
     opCode = 55,
     displayName = "Bolus Activated",
@@ -13,23 +11,43 @@ import java.math.BigInteger;
     usedByTidepool = true
 )
 public class BolusActivatedHistoryLog extends HistoryLog {
-    
+
     private int bolusId;
+    private int selectedIob;
     private float iob;
     private float bolusSize;
-    
+
     public BolusActivatedHistoryLog() {}
-    public BolusActivatedHistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, float iob, float bolusSize) {
-        super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, iob, bolusSize);
-        this.bolusId = bolusId;
-        this.iob = iob;
-        this.bolusSize = bolusSize;
-        
+
+    public BolusActivatedHistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize) {
+        this(pumpTimeSec, sequenceNum, bolusId, selectedIob, iob, bolusSize, 0);
     }
 
+    public BolusActivatedHistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int logGeneration) {
+        super(pumpTimeSec, sequenceNum);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, selectedIob, iob, bolusSize, logGeneration);
+        this.bolusId = bolusId;
+        this.selectedIob = selectedIob;
+        this.iob = iob;
+        this.bolusSize = bolusSize;
+
+    }
+
+    /**
+     * @deprecated bytes 12-13 of this log are not padding: byte 12 carries selectedIob. This
+     * constructor assumes a selectedIob of 0, which does not round-trip a record where it is 1.
+     */
+    @Deprecated
+    public BolusActivatedHistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, float iob, float bolusSize) {
+        this(pumpTimeSec, sequenceNum, bolusId, 0, iob, bolusSize);
+    }
+
+    /**
+     * @deprecated see {@link #BolusActivatedHistoryLog(long, long, int, float, float)}
+     */
+    @Deprecated
     public BolusActivatedHistoryLog(int bolusId, float iob, float bolusSize) {
-        this(0, 0, bolusId, iob, bolusSize);
+        this(0, 0, bolusId, 0, iob, bolusSize);
     }
 
     public int typeId() {
@@ -41,28 +59,65 @@ public class BolusActivatedHistoryLog extends HistoryLog {
         this.cargo = raw;
         parseBase(raw);
         this.bolusId = Bytes.readShort(raw, 10);
+        this.selectedIob = raw[12];
         this.iob = Bytes.readFloat(raw, 14);
         this.bolusSize = Bytes.readFloat(raw, 18);
-        
+
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, float iob, float bolusSize) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize) {
+        return buildCargo(pumpTimeSec, sequenceNum, bolusId, selectedIob, iob, bolusSize, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int logGeneration) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{55, 0},
+            HistoryLog.typeIdBytes(55, logGeneration),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            Bytes.firstTwoBytesLittleEndian(bolusId), 
-            Bytes.toFloat(iob), 
+            Bytes.firstTwoBytesLittleEndian(bolusId),
+            // bytes 12-13: selectedIob followed by one unused byte, which is 0 in every known
+            // record. These were previously omitted entirely, which shifted iob and bolusSize
+            // 2 bytes earlier than parse() reads them.
+            new byte[]{ (byte) selectedIob, 0 },
+            Bytes.toFloat(iob),
             Bytes.toFloat(bolusSize)));
     }
+
+    /**
+     * @return the ID of the bolus operation
+     */
     public int getBolusId() {
         return bolusId;
     }
+
+    /**
+     * @return the raw value of byte 12, which tracks the IOB algorithm in use.
+     *
+     * <p>This is an inference drawn from a small number of records, in which byte 12 co-varies
+     * exactly with {@link BolusRequestedMsg2HistoryLog#getSelectedIOB()} for the same bolus. It
+     * should be confirmed against further captures before being relied upon. The byte offsets
+     * either side of it are independently confirmed.
+     */
+    public int getSelectedIob() {
+        return selectedIob;
+    }
+
+    public BolusRequestedMsg2HistoryLog.SelectedIOBType getSelectedIobType() {
+        return BolusRequestedMsg2HistoryLog.SelectedIOBType.fromId(selectedIob);
+    }
+
+    /**
+     * @return current insulin on board
+     */
     public float getIob() {
         return iob;
     }
+
+    /**
+     * @return the size of the bolus which was activated
+     */
     public float getBolusSize() {
         return bolusSize;
     }
-    
+
 }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusCompletedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusCompletedHistoryLog.java
@@ -26,8 +26,8 @@ public class BolusCompletedHistoryLog extends HistoryLog {
         this(pumpTimeSec, sequenceNum, completionStatusId, bolusId, iob, insulinDelivered, insulinRequested, 0);
     }
 
-    public BolusCompletedHistoryLog(long pumpTimeSec, long sequenceNum, int completionStatusId, int bolusId, float iob, float insulinDelivered, float insulinRequested, int logGeneration) {
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, completionStatusId, bolusId, iob, insulinDelivered, insulinRequested, logGeneration);
+    public BolusCompletedHistoryLog(long pumpTimeSec, long sequenceNum, int completionStatusId, int bolusId, float iob, float insulinDelivered, float insulinRequested, int headerHighNibble) {
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, completionStatusId, bolusId, iob, insulinDelivered, insulinRequested, headerHighNibble);
         this.pumpTimeSec = pumpTimeSec;
         this.sequenceNum = sequenceNum;
         this.completionStatusId = completionStatusId;
@@ -59,9 +59,9 @@ public class BolusCompletedHistoryLog extends HistoryLog {
         return buildCargo(pumpTimeSec, sequenceNum, completionStatus, bolusId, iob, insulinDelivered, insulinRequested, 0);
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested, int logGeneration) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested, int headerHighNibble) {
         return Bytes.combine(
-            HistoryLog.typeIdBytes(20, logGeneration),
+            HistoryLog.typeIdBytes(20, headerHighNibble),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(completionStatus),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusCompletedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusCompletedHistoryLog.java
@@ -23,7 +23,11 @@ public class BolusCompletedHistoryLog extends HistoryLog {
     public BolusCompletedHistoryLog() {}
     
     public BolusCompletedHistoryLog(long pumpTimeSec, long sequenceNum, int completionStatusId, int bolusId, float iob, float insulinDelivered, float insulinRequested) {
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, completionStatusId, bolusId, iob, insulinDelivered, insulinRequested);
+        this(pumpTimeSec, sequenceNum, completionStatusId, bolusId, iob, insulinDelivered, insulinRequested, 0);
+    }
+
+    public BolusCompletedHistoryLog(long pumpTimeSec, long sequenceNum, int completionStatusId, int bolusId, float iob, float insulinDelivered, float insulinRequested, int logGeneration) {
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, completionStatusId, bolusId, iob, insulinDelivered, insulinRequested, logGeneration);
         this.pumpTimeSec = pumpTimeSec;
         this.sequenceNum = sequenceNum;
         this.completionStatusId = completionStatusId;
@@ -52,8 +56,12 @@ public class BolusCompletedHistoryLog extends HistoryLog {
 
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested) {
+        return buildCargo(pumpTimeSec, sequenceNum, completionStatus, bolusId, iob, insulinDelivered, insulinRequested, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested, int logGeneration) {
         return Bytes.combine(
-            new byte[]{20, 0},
+            HistoryLog.typeIdBytes(20, logGeneration),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(completionStatus),
@@ -91,6 +99,8 @@ public class BolusCompletedHistoryLog extends HistoryLog {
     /**
      * @return the amount of insulin delivered, in real units. Note that due to ieee float
      * precision, even if the bolus was completed fully this may differ from the units requested
+     * by one unit in the last place; compare against {@link #getInsulinRequested()} with a
+     * tolerance of {@link HistoryLog#INSULIN_FLOAT_EPSILON} rather than testing float equality
      */
     public float getInsulinDelivered() {
         return insulinDelivered;

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg1HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg1HistoryLog.java
@@ -4,8 +4,6 @@ import org.apache.commons.lang3.Validate;
 import com.jwoglom.pumpx2.pump.messages.annotations.HistoryLogProps;
 import com.jwoglom.pumpx2.pump.messages.helpers.Bytes;
 
-import java.util.Set;
-
 @HistoryLogProps(
     opCode = 64,
     displayName = "Bolus Requested 1/3",
@@ -26,10 +24,14 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
     public BolusRequestedMsg1HistoryLog() {}
     
     public BolusRequestedMsg1HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int bolusTypeId, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio) {
+        this(pumpTimeSec, sequenceNum, bolusId, bolusTypeId, correctionBolusIncluded, carbAmount, bg, iob, carbRatio, 0);
+    }
+
+    public BolusRequestedMsg1HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int bolusTypeId, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int logGeneration) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, bolusTypeId, correctionBolusIncluded, carbAmount, bg, iob, carbRatio);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, bolusTypeId, correctionBolusIncluded, carbAmount, bg, iob, carbRatio, logGeneration);
         this.bolusId = bolusId;
-        this.bolusTypeId = bolusTypeId; // probably the same bolusType enum as BolusDeliveryHistoryLog
+        this.bolusTypeId = bolusTypeId;
         this.correctionBolusIncluded = correctionBolusIncluded;
         this.carbAmount = carbAmount;
         this.bg = bg;
@@ -58,8 +60,12 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
 
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int bolusType, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio) {
+        return buildCargo(pumpTimeSec, sequenceNum, bolusId, bolusType, correctionBolusIncluded, carbAmount, bg, iob, carbRatio, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int bolusType, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int logGeneration) {
         return Bytes.combine(
-            new byte[]{64, 0},
+            HistoryLog.typeIdBytes(64, logGeneration),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId), 
@@ -83,10 +89,49 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
     }
 
     /**
-     * @return Bolus types
+     * @return how the bolus was requested, or null if the raw value is not recognized.
+     *
+     * <p>Note that this is a scalar enum, not the bitmask used by
+     * {@link BolusDeliveryHistoryLog#getBolusTypes()}. Decoding it as a bitmask is contradicted by
+     * the data: a raw value of 3 would decode to FOOD1|CORRECTION, but records carrying 3 also
+     * report {@link #getCorrectionBolusIncluded()} false and a correction bolus size of zero in
+     * {@link BolusRequestedMsg3HistoryLog}. As a scalar, 3 is {@link BolusType#REMOTE}, which is
+     * consistent with those records having been commanded over Bluetooth.
      */
-    public Set<BolusDeliveryHistoryLog.BolusType> getBolusType() {
-        return BolusDeliveryHistoryLog.BolusType.fromBitmask(bolusTypeId);
+    public BolusType getBolusType() {
+        return BolusType.fromId(bolusTypeId);
+    }
+
+    /**
+     * The way in which a bolus was requested, as reported by this log only.
+     *
+     * <p>Deliberately distinct from {@link BolusDeliveryHistoryLog.BolusType}, which is a bitmask
+     * of the components making up a bolus and is a different field with a different encoding.
+     */
+    public enum BolusType {
+        INSULIN(0),
+        CARB(1),
+        AUTOMATIC_CORRECTION(2),
+        REMOTE(3),
+        ;
+
+        private final int id;
+        BolusType(int id) {
+            this.id = id;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public static BolusType fromId(int id) {
+            for (BolusType b : values()) {
+                if (b.id() == id) {
+                    return b;
+                }
+            }
+            return null;
+        }
     }
 
     /**
@@ -97,30 +142,46 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
     }
 
     /**
-     * @return carbs in grams
+     * @return carbs in grams.
+     *
+     * <p>The ordering of this field and {@link #getBg()} is the one field pair in this log which
+     * has not been independently confirmed against a capture: every record examined so far was
+     * either commanded remotely or entered without a fingerstick, leaving both fields zero. The
+     * offsets either side of the pair are confirmed.
      */
     public int getCarbAmount() {
         return carbAmount;
     }
 
     /**
-     * @return BG in mg/dL
+     * @return BG in mg/dL. See the note on {@link #getCarbAmount()} regarding this field's offset.
      */
     public int getBg() {
         return bg;
     }
 
     /**
-     * @return current insulin on board
+     * @return current insulin on board.
+     *
+     * <p>This field is zero on some pumps which report a nonzero IOB for the same bolus in
+     * {@link BolusActivatedHistoryLog} and {@link BolusCompletedHistoryLog}. Prefer those logs as
+     * the source of IOB.
      */
     public float getIob() {
         return iob;
     }
 
     /**
-     * @return carb ratio from the insulin delivery profile
+     * @return carb ratio from the insulin delivery profile, in thousandths of a gram per unit
      */
     public long getCarbRatio() {
         return carbRatio;
+    }
+
+    /**
+     * @return carb ratio from the insulin delivery profile, in grams per unit
+     */
+    public double getCarbRatioGramsPerUnit() {
+        return carbRatio / 1000.0;
     }
 }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg1HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg1HistoryLog.java
@@ -27,9 +27,9 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
         this(pumpTimeSec, sequenceNum, bolusId, bolusTypeId, correctionBolusIncluded, carbAmount, bg, iob, carbRatio, 0);
     }
 
-    public BolusRequestedMsg1HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int bolusTypeId, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int logGeneration) {
+    public BolusRequestedMsg1HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int bolusTypeId, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int headerHighNibble) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, bolusTypeId, correctionBolusIncluded, carbAmount, bg, iob, carbRatio, logGeneration);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, bolusTypeId, correctionBolusIncluded, carbAmount, bg, iob, carbRatio, headerHighNibble);
         this.bolusId = bolusId;
         this.bolusTypeId = bolusTypeId;
         this.correctionBolusIncluded = correctionBolusIncluded;
@@ -63,9 +63,9 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
         return buildCargo(pumpTimeSec, sequenceNum, bolusId, bolusType, correctionBolusIncluded, carbAmount, bg, iob, carbRatio, 0);
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int bolusType, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int logGeneration) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int bolusType, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int headerHighNibble) {
         return Bytes.combine(
-            HistoryLog.typeIdBytes(64, logGeneration),
+            HistoryLog.typeIdBytes(64, headerHighNibble),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId), 
@@ -91,12 +91,15 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
     /**
      * @return how the bolus was requested, or null if the raw value is not recognized.
      *
-     * <p>Note that this is a scalar enum, not the bitmask used by
-     * {@link BolusDeliveryHistoryLog#getBolusTypes()}. Decoding it as a bitmask is contradicted by
-     * the data: a raw value of 3 would decode to FOOD1|CORRECTION, but records carrying 3 also
-     * report {@link #getCorrectionBolusIncluded()} false and a correction bolus size of zero in
-     * {@link BolusRequestedMsg3HistoryLog}. As a scalar, 3 is {@link BolusType#REMOTE}, which is
-     * consistent with those records having been commanded over Bluetooth.
+     * <p>Treated as a scalar enum rather than the bitmask used by
+     * {@link BolusDeliveryHistoryLog#getBolusTypes()}. <b>Unverified against this repository's
+     * fixtures.</b> The scalar reading, and the value names below, are taken from the tconnectsync
+     * Python implementation by way of the analysis attached to the linked issue; the supporting
+     * observation reported there is that records carrying a raw value of 3 also report
+     * {@link #getCorrectionBolusIncluded()} false and a correction size of zero, which a
+     * FOOD1|CORRECTION bitmask reading could not explain. The only records committed here carry 1
+     * and 2, so neither reading is discriminated by anything in this repository. Confirm against a
+     * capture before relying on this for therapy-relevant decoding.
      */
     public BolusType getBolusType() {
         return BolusType.fromId(bolusTypeId);
@@ -104,6 +107,9 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
 
     /**
      * The way in which a bolus was requested, as reported by this log only.
+     *
+     * <p>Value names ported from tconnectsync and not independently verified here; see
+     * {@link #getBolusType()}.
      *
      * <p>Deliberately distinct from {@link BolusDeliveryHistoryLog.BolusType}, which is a bitmask
      * of the components making up a bolus and is a different field with a different encoding.
@@ -144,10 +150,9 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
     /**
      * @return carbs in grams.
      *
-     * <p>The ordering of this field and {@link #getBg()} is the one field pair in this log which
-     * has not been independently confirmed against a capture: every record examined so far was
-     * either commanded remotely or entered without a fingerstick, leaving both fields zero. The
-     * offsets either side of the pair are confirmed.
+     * <p>The ordering of this field and {@link #getBg()} is unconfirmed. Both are zero in every
+     * record committed to this repository, so nothing here distinguishes this ordering from the
+     * reverse.
      */
     public int getCarbAmount() {
         return carbAmount;
@@ -163,9 +168,10 @@ public class BolusRequestedMsg1HistoryLog extends HistoryLog {
     /**
      * @return current insulin on board.
      *
-     * <p>This field is zero on some pumps which report a nonzero IOB for the same bolus in
-     * {@link BolusActivatedHistoryLog} and {@link BolusCompletedHistoryLog}. Prefer those logs as
-     * the source of IOB.
+     * <p>The analysis attached to the linked issue reports this field reading zero on records
+     * whose corresponding {@link BolusActivatedHistoryLog} and {@link BolusCompletedHistoryLog}
+     * carry a nonzero IOB, and recommends preferring those logs as the source of IOB. Not
+     * reproduced here; the records committed to this repository carry a nonzero value.
      */
     public float getIob() {
         return iob;

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLog.java
@@ -28,7 +28,11 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
     public BolusRequestedMsg2HistoryLog() {}
     
     public BolusRequestedMsg2HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2) {
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2);
+        this(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2, 0);
+    }
+
+    public BolusRequestedMsg2HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int logGeneration) {
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2, logGeneration);
         this.pumpTimeSec = pumpTimeSec;
         this.sequenceNum = sequenceNum;
         this.bolusId = bolusId;
@@ -72,8 +76,12 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
 
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2) {
+        return buildCargo(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int logGeneration) {
         return Bytes.combine(
-            new byte[] { (byte) 65, 0},
+            HistoryLog.typeIdBytes(65, logGeneration),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId), 
@@ -95,8 +103,52 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
     public int getBolusId() {
         return bolusId;
     }
+    /**
+     * @return the raw value of the options byte, see {@link #getBolusOption()}
+     */
     public int getOptions() {
         return options;
+    }
+
+    /**
+     * @return how the bolus was requested, or null if the raw value is not recognized
+     */
+    public BolusOption getBolusOption() {
+        return BolusOption.fromId(options);
+    }
+
+    /**
+     * How the bolus was requested. A bolus commanded over Bluetooth by an app such as this one
+     * reports {@link #BLE_STANDARD}, not {@link #STANDARD}.
+     */
+    public enum BolusOption {
+        STANDARD(0),
+        EXTENDED(1),
+        QUICK(2),
+        AUTOMATIC(3),
+        BLE_STANDARD(4),
+        BLE_EXTENDED(5),
+        EATING_SOON_AUTOMATIC(6),
+        LATE_BOLUS(7),
+        ;
+
+        private final int id;
+        BolusOption(int id) {
+            this.id = id;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public static BolusOption fromId(int id) {
+            for (BolusOption o : values()) {
+                if (o.id() == id) {
+                    return o;
+                }
+            }
+            return null;
+        }
     }
 
     /**
@@ -148,10 +200,46 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
     }
 
     /**
-     * @return TODO(unknown)
+     * @return the raw value identifying which IOB algorithm the bolus calculator used,
+     * see {@link #getSelectedIOBType()}
      */
     public int getSelectedIOB() {
         return selectedIOB;
+    }
+
+    /**
+     * @return the IOB algorithm the bolus calculator used, or null if the raw value is not
+     * recognized
+     */
+    public SelectedIOBType getSelectedIOBType() {
+        return SelectedIOBType.fromId(selectedIOB);
+    }
+
+    /**
+     * The IOB algorithm used when calculating the bolus.
+     */
+    public enum SelectedIOBType {
+        MUDALIAR_IOB(0),
+        SWAN_IOB_MEAL(1),
+        ;
+
+        private final int id;
+        SelectedIOBType(int id) {
+            this.id = id;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public static SelectedIOBType fromId(int id) {
+            for (SelectedIOBType s : values()) {
+                if (s.id() == id) {
+                    return s;
+                }
+            }
+            return null;
+        }
     }
     public int getSpare2() {
         return spare2;

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLog.java
@@ -31,8 +31,8 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
         this(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2, 0);
     }
 
-    public BolusRequestedMsg2HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int logGeneration) {
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2, logGeneration);
+    public BolusRequestedMsg2HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int headerHighNibble) {
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2, headerHighNibble);
         this.pumpTimeSec = pumpTimeSec;
         this.sequenceNum = sequenceNum;
         this.bolusId = bolusId;
@@ -79,9 +79,9 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
         return buildCargo(pumpTimeSec, sequenceNum, bolusId, options, standardPercent, duration, spare1, isf, targetBG, userOverride, declinedCorrection, selectedIOB, spare2, 0);
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int logGeneration) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int headerHighNibble) {
         return Bytes.combine(
-            HistoryLog.typeIdBytes(65, logGeneration),
+            HistoryLog.typeIdBytes(65, headerHighNibble),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId), 
@@ -118,8 +118,11 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
     }
 
     /**
-     * How the bolus was requested. A bolus commanded over Bluetooth by an app such as this one
-     * reports {@link #BLE_STANDARD}, not {@link #STANDARD}.
+     * How the bolus was requested.
+     *
+     * <p><b>Value names ported from the tconnectsync Python implementation and not verified
+     * here.</b> No record committed to this repository exercises them. Confirm against a capture
+     * before relying on these labels.
      */
     public enum BolusOption {
         STANDARD(0),
@@ -217,6 +220,10 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
 
     /**
      * The IOB algorithm used when calculating the bolus.
+     *
+     * <p><b>Value names ported from the tconnectsync Python implementation and not verified
+     * here.</b> The field previously carried a {@code TODO(unknown)} javadoc; these names replace
+     * that with a secondhand attribution, not with a confirmed one.
      */
     public enum SelectedIOBType {
         MUDALIAR_IOB(0),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg3HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg3HistoryLog.java
@@ -25,8 +25,8 @@ public class BolusRequestedMsg3HistoryLog extends HistoryLog {
         this(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize, 0);
     }
 
-    public BolusRequestedMsg3HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int logGeneration) {
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize, logGeneration);
+    public BolusRequestedMsg3HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int headerHighNibble) {
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize, headerHighNibble);
         this.pumpTimeSec = pumpTimeSec;
         this.sequenceNum = sequenceNum;
         this.bolusId = bolusId;
@@ -61,9 +61,9 @@ public class BolusRequestedMsg3HistoryLog extends HistoryLog {
         return buildCargo(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize, 0);
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int logGeneration) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int headerHighNibble) {
         return Bytes.combine(
-            HistoryLog.typeIdBytes(66, logGeneration),
+            HistoryLog.typeIdBytes(66, headerHighNibble),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg3HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg3HistoryLog.java
@@ -22,7 +22,11 @@ public class BolusRequestedMsg3HistoryLog extends HistoryLog {
     public BolusRequestedMsg3HistoryLog() {}
     
     public BolusRequestedMsg3HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize) {
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize);
+        this(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize, 0);
+    }
+
+    public BolusRequestedMsg3HistoryLog(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int logGeneration) {
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize, logGeneration);
         this.pumpTimeSec = pumpTimeSec;
         this.sequenceNum = sequenceNum;
         this.bolusId = bolusId;
@@ -54,8 +58,12 @@ public class BolusRequestedMsg3HistoryLog extends HistoryLog {
 
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize) {
+        return buildCargo(pumpTimeSec, sequenceNum, bolusId, spare, foodBolusSize, correctionBolusSize, totalBolusSize, 0);
+    }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int logGeneration) {
         return Bytes.combine(
-            new byte[] { (byte) 66, 0},
+            HistoryLog.typeIdBytes(66, logGeneration),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId), 
@@ -93,6 +101,12 @@ public class BolusRequestedMsg3HistoryLog extends HistoryLog {
      * @return the total bolus amount which is scheduled to be delivered following this message.
      * note that this may not be correctionBolusSize+foodBolusSize if the amounts are overridden,
      * or due to ieee float arithmetic
+     *
+     * <p>Where the amounts are not overridden the identity holds, but the pump recomputes the
+     * total in float, so a small number of records differ from the sum by one unit in the last
+     * place. Compare with a tolerance of {@link HistoryLog#INSULIN_FLOAT_EPSILON} rather than
+     * exact float equality, and do not use exact equality on these values as a reconciliation or
+     * deduplication key.
      */
     public float getTotalBolusSize() {
         return totalBolusSize;

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyStatusHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyStatusHistoryLog.java
@@ -45,7 +45,7 @@ public class DailyStatusHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int sensorType, int userMode, int pumpControlState) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 313, 0},
+            HistoryLog.typeIdBytes(313, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{0, (byte) sensorType, (byte) userMode, (byte) pumpControlState}));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
@@ -54,17 +54,22 @@ public abstract class HistoryLog {
     public abstract void parse(byte[] raw);
 
     /**
-     * The first two bytes of a history log are a little-endian uint16. {@link #parseBase} masks
-     * that value with 4095 to obtain the typeId, so the top 4 bits are not part of the typeId.
+     * The first two bytes of a history log are a little-endian uint16 whose low 12 bits are the
+     * typeId, leaving these top 4 bits over.
      *
-     * <p><b>What these bits mean is unknown.</b> The only records in this repository which carry a
-     * nonzero value here are the {@link DexcomG7CGMHistoryLog} fixtures, which carry 1. No claim is
-     * made about what distinguishes those records from the ones carrying 0, and the 12/4 split
-     * itself rests only on the pre-existing mask in {@code parseBase}, not on anything observed.
+     * <p>The 12/4 split is confirmed by Tandem's own Mobi Android app, which reads the first two
+     * bytes little endian and masks with 4095 before looking up the log type
+     * ({@code HistoryLogStreamResponse$HistoryLogStreamCargo}).
      *
-     * <p>The value is read and preserved so that {@code buildCargo} can reproduce such a record
-     * byte for byte, which is the only reason this accessor exists. Do not infer a pump model, a
-     * firmware version, or a log format from it without evidence.
+     * <p><b>What the top 4 bits mean is unknown, and Tandem's app does not appear to care.</b> It
+     * masks them off and discards them: its {@code HistoryLog} model stores the raw bytes, the
+     * masked type, the timestamp, the sequence number and four 4-byte payload fields, with nothing
+     * corresponding to these bits, and nothing in the decompiled app reads them back. The only
+     * records in this repository carrying a nonzero value here are the
+     * {@link DexcomG7CGMHistoryLog} fixtures, which carry 1.
+     *
+     * <p>The value is read and preserved only so that {@code buildCargo} can reproduce such a
+     * record byte for byte. Do not infer a pump model, a firmware version, or a log format from it.
      *
      * @return the top 4 bits of the first two cargo bytes, or 0 if the cargo is not populated
      */

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
@@ -17,11 +17,12 @@ public abstract class HistoryLog {
      * Tolerance, in units of insulin, for comparing the float insulin amounts reported across
      * history logs.
      *
-     * <p>The pump recomputes these amounts rather than copying them, so values which are
-     * arithmetically equal can differ by one unit in the last place: a bolus can report a
-     * requested amount of 0.25 in one log and 0.2500000298 in another. Consumers reconciling or
-     * deduplicating boluses across logs should compare within this tolerance rather than testing
-     * float equality.
+     * <p>Values which are arithmetically equal can differ by one unit in the last place across
+     * logs, so consumers reconciling or deduplicating boluses should compare within this tolerance
+     * rather than testing float equality. The observation motivating this (a requested amount
+     * reading 0.25 in one log and 0.2500000298 in another, attributed to the pump recomputing
+     * rather than copying the value) is reported in the analysis attached to the linked issue and
+     * is not reproduced by any record committed to this repository.
      */
     public static final float INSULIN_FLOAT_EPSILON = 1e-6f;
 
@@ -53,16 +54,21 @@ public abstract class HistoryLog {
     public abstract void parse(byte[] raw);
 
     /**
-     * The first two bytes of a history log are a little-endian uint16 whose low 12 bits are the
-     * typeId. The remaining high nibble is 0 on t:slim X2 logs and 1 on Tandem Mobi logs, so it
-     * appears to be a log format or pump generation discriminator.
+     * The first two bytes of a history log are a little-endian uint16. {@link #parseBase} masks
+     * that value with 4095 to obtain the typeId, so the top 4 bits are not part of the typeId.
      *
-     * <p>Its exact meaning is not confirmed. It is exposed so that consumers can distinguish the
-     * two encodings, and so that {@code buildCargo} can round-trip a Mobi record byte-for-byte.
+     * <p><b>What these bits mean is unknown.</b> The only records in this repository which carry a
+     * nonzero value here are the {@link DexcomG7CGMHistoryLog} fixtures, which carry 1. No claim is
+     * made about what distinguishes those records from the ones carrying 0, and the 12/4 split
+     * itself rests only on the pre-existing mask in {@code parseBase}, not on anything observed.
      *
-     * @return the high nibble of the first two cargo bytes, or 0 if the cargo is not populated
+     * <p>The value is read and preserved so that {@code buildCargo} can reproduce such a record
+     * byte for byte, which is the only reason this accessor exists. Do not infer a pump model, a
+     * firmware version, or a log format from it without evidence.
+     *
+     * @return the top 4 bits of the first two cargo bytes, or 0 if the cargo is not populated
      */
-    public int getLogGeneration() {
+    public int getHeaderHighNibble() {
         if (cargo == null || cargo.length < 2) {
             return 0;
         }
@@ -70,18 +76,18 @@ public abstract class HistoryLog {
     }
 
     /**
-     * Builds the leading two cargo bytes from a typeId and a log generation nibble.
-     * With a generation of 0 this is identical to the historical {@code new byte[]{typeId, 0}},
-     * except that it does not truncate a typeId above 255.
+     * Builds the leading two cargo bytes from a typeId and the high nibble described in
+     * {@link #getHeaderHighNibble()}. With a nibble of 0 this is identical to the historical
+     * {@code new byte[]{typeId, 0}}, except that it does not truncate a typeId above 255.
      *
      * @param typeId the history log typeId, which occupies the low 12 bits
-     * @param logGeneration the log generation nibble, see {@link #getLogGeneration()}
+     * @param headerHighNibble the top 4 bits, of unknown meaning, see {@link #getHeaderHighNibble()}
      * @return the first two bytes of the cargo, little endian
      */
-    public static byte[] typeIdBytes(int typeId, int logGeneration) {
+    public static byte[] typeIdBytes(int typeId, int headerHighNibble) {
         return new byte[]{
             (byte) (typeId & 0xFF),
-            (byte) (((typeId >> 8) & 0x0F) | ((logGeneration & 0x0F) << 4))
+            (byte) (((typeId >> 8) & 0x0F) | ((headerHighNibble & 0x0F) << 4))
         };
     }
 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
@@ -13,6 +13,18 @@ import java.util.HashSet;
 import java.util.Set;
 
 public abstract class HistoryLog {
+    /**
+     * Tolerance, in units of insulin, for comparing the float insulin amounts reported across
+     * history logs.
+     *
+     * <p>The pump recomputes these amounts rather than copying them, so values which are
+     * arithmetically equal can differ by one unit in the last place: a bolus can report a
+     * requested amount of 0.25 in one log and 0.2500000298 in another. Consumers reconciling or
+     * deduplicating boluses across logs should compare within this tolerance rather than testing
+     * float equality.
+     */
+    public static final float INSULIN_FLOAT_EPSILON = 1e-6f;
+
     protected byte[] cargo = null;
 
     public HistoryLog() {}
@@ -39,6 +51,39 @@ public abstract class HistoryLog {
     }
 
     public abstract void parse(byte[] raw);
+
+    /**
+     * The first two bytes of a history log are a little-endian uint16 whose low 12 bits are the
+     * typeId. The remaining high nibble is 0 on t:slim X2 logs and 1 on Tandem Mobi logs, so it
+     * appears to be a log format or pump generation discriminator.
+     *
+     * <p>Its exact meaning is not confirmed. It is exposed so that consumers can distinguish the
+     * two encodings, and so that {@code buildCargo} can round-trip a Mobi record byte-for-byte.
+     *
+     * @return the high nibble of the first two cargo bytes, or 0 if the cargo is not populated
+     */
+    public int getLogGeneration() {
+        if (cargo == null || cargo.length < 2) {
+            return 0;
+        }
+        return (Bytes.readShort(cargo, 0) >>> 12) & 0x0F;
+    }
+
+    /**
+     * Builds the leading two cargo bytes from a typeId and a log generation nibble.
+     * With a generation of 0 this is identical to the historical {@code new byte[]{typeId, 0}},
+     * except that it does not truncate a typeId above 255.
+     *
+     * @param typeId the history log typeId, which occupies the low 12 bits
+     * @param logGeneration the log generation nibble, see {@link #getLogGeneration()}
+     * @return the first two bytes of the cargo, little endian
+     */
+    public static byte[] typeIdBytes(int typeId, int logGeneration) {
+        return new byte[]{
+            (byte) (typeId & 0xFF),
+            (byte) (((typeId >> 8) & 0x0F) | ((logGeneration & 0x0F) << 4))
+        };
+    }
 
     /**
      * Parses the typeId (checked against the superclass static typeId),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
@@ -122,7 +122,8 @@ public class HistoryLogParser {
      * <p>Those bytes are a little-endian uint16 whose low 12 bits are the typeId. The top 4 bits
      * are not part of the id and their meaning is unknown, see
      * {@link HistoryLog#getHeaderHighNibble()}. This applies the same mask
-     * {@link HistoryLog#parseBase} already used.
+     * {@link HistoryLog#parseBase} already used, and matches Tandem's own Mobi Android app, which
+     * reads these two bytes little endian and masks with 4095 before resolving the log type.
      *
      * <p>Without the mask, a record carrying a nonzero high nibble produces an inflated typeId
      * (opCode 55 with a nibble of 1 reads as 4151), misses {@link #LOG_MESSAGE_IDS}, and is only

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
@@ -119,11 +119,16 @@ public class HistoryLogParser {
     /**
      * Reads the typeId from the first two bytes of a raw history log.
      *
-     * <p>Those bytes are a little-endian uint16 whose low 12 bits are the typeId; the high nibble
-     * is a log format/generation discriminator (0 on t:slim X2, 1 on Mobi) and is not part of the
-     * id. This is the same mask {@link HistoryLog#parseBase} applies. Without it a Mobi opCode 55
-     * reads as typeId 4151, misses {@link #LOG_MESSAGE_IDS}, and is only recovered by the retry
-     * ladder in {@link #parse}, which logs a warning for every single history log.
+     * <p>Those bytes are a little-endian uint16 whose low 12 bits are the typeId. The top 4 bits
+     * are not part of the id and their meaning is unknown, see
+     * {@link HistoryLog#getHeaderHighNibble()}. This applies the same mask
+     * {@link HistoryLog#parseBase} already used.
+     *
+     * <p>Without the mask, a record carrying a nonzero high nibble produces an inflated typeId
+     * (opCode 55 with a nibble of 1 reads as 4151), misses {@link #LOG_MESSAGE_IDS}, and is only
+     * recovered by the retry ladder in {@link #parse}, which logs a warning for every such record.
+     * The masking also corrects dispatch for typeIds of 128-255, which the previous signed-byte
+     * arithmetic resolved to typeId+256.
      */
     public static int typeIdOf(byte[] rawStream) {
         return Bytes.readShort(rawStream, 0) & 4095;

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
@@ -116,19 +116,21 @@ public class HistoryLogParser {
         }
     }
 
+    /**
+     * Reads the typeId from the first two bytes of a raw history log.
+     *
+     * <p>Those bytes are a little-endian uint16 whose low 12 bits are the typeId; the high nibble
+     * is a log format/generation discriminator (0 on t:slim X2, 1 on Mobi) and is not part of the
+     * id. This is the same mask {@link HistoryLog#parseBase} applies. Without it a Mobi opCode 55
+     * reads as typeId 4151, misses {@link #LOG_MESSAGE_IDS}, and is only recovered by the retry
+     * ladder in {@link #parse}, which logs a warning for every single history log.
+     */
+    public static int typeIdOf(byte[] rawStream) {
+        return Bytes.readShort(rawStream, 0) & 4095;
+    }
+
     public static HistoryLog parse(byte[] rawStream) {
-        // Little endian, unsigned
-        int typeId = rawStream[0];
-        if (typeId < 0) {
-            typeId += 512;
-        }
-        if (rawStream[1] > 0) {
-            typeId += 256 * rawStream[1];
-        }
-//        if (typeId % 256 != typeId) {
-//            L.w(TAG, "typeId "+typeId+" is being corrected to "+(typeId % 256));
-//            typeId = typeId % 256;
-//        }
+        int typeId = typeIdOf(rawStream);
         HistoryLog ret = parseWithTypeId(rawStream, typeId);
         if (ret instanceof UnknownHistoryLog) {
             L.w(TAG, "retry1 HistoryLog parse on typeId " + typeId + " => " + ((byte) typeId));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/VersionsAHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/VersionsAHistoryLog.java
@@ -48,7 +48,7 @@ public class VersionsAHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long armPartNumber, long armSwVersion, long blePartNumber, long bleSwVersion) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 307, 0},
+            HistoryLog.typeIdBytes(307, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(armPartNumber),

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusActivatedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusActivatedHistoryLogTest.java
@@ -2,40 +2,35 @@ package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
 
-import com.jwoglom.pumpx2.pump.messages.MessageTester;
-import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID;
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.BolusActivatedHistoryLog;
-
-import java.util.Arrays;
 import org.apache.commons.codec.DecoderException;
-import org.junit.Ignore;
 import org.junit.Test;
+
 public class BolusActivatedHistoryLogTest {
     @Test
     public void testBolusActivatedHistoryLog1() throws DecoderException {
         BolusActivatedHistoryLog expected = new BolusActivatedHistoryLog(
-            // int bolusId, float iob, float bolusSize
-            1037, 0.0F, 1.1F
-
+            // long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize
+            446033777L, 182751L, 1037, 1, 0.0F, 1.1F
         );
 
-        BolusActivatedHistoryLog parsedRes = (BolusActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
+        BolusActivatedHistoryLog parsedRes = (BolusActivatedHistoryLog) HistoryLogMessageTester.testSingle(
                 "370071ef951adfc902000d04010000000000cdcc8c3f00000000",
                 expected
         );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testBolusActivatedHistoryLog2() throws DecoderException {
         BolusActivatedHistoryLog expected = new BolusActivatedHistoryLog(
-                // int bolusId, float iob, float bolusSize
-                1053, 2.0116007F, 0.5F
-
+                // long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize
+                446141315L, 185926L, 1053, 1, 2.0116007F, 0.5F
         );
 
-        BolusActivatedHistoryLog parsedRes = (BolusActivatedHistoryLog) HistoryLogMessageTester.testSingleIgnoringBaseFields(
+        BolusActivatedHistoryLog parsedRes = (BolusActivatedHistoryLog) HistoryLogMessageTester.testSingle(
                 "37008393971a46d602001d04010011be00400000003f00000000",
                 expected
         );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusHeaderNibbleHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusHeaderNibbleHistoryLogTest.java
@@ -11,23 +11,23 @@ import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
 /**
- * Round-trip coverage for the five bolus history logs as emitted by a Tandem Mobi, whose logs
- * carry a log generation nibble of 1 in the high bits of the first two cargo bytes (so opCode 55
- * is transmitted as {@code 37 10}, not {@code 37 00}).
+ * Round-trip coverage for the five bolus history logs when the top 4 bits of the first two cargo
+ * bytes are nonzero, so that opCode 55 arrives as {@code 37 10} rather than {@code 37 00}. See
+ * {@link HistoryLog#getHeaderHighNibble()}: what those bits mean is unknown.
  *
- * <p>Every existing fixture in this package comes from a t:slim X2 and carries a generation of 0,
- * so nothing else in the suite exercises that nibble: neither the dispatch path in
- * {@link HistoryLogParser} nor the ability of {@code buildCargo} to reproduce such a record.
+ * <p>Records with a nonzero value there do occur — the {@link DexcomG7CGMHistoryLog} fixtures in
+ * this package carry 1 — but no bolus fixture did, so nothing exercised the dispatch path in
+ * {@link HistoryLogParser} or the ability of {@code buildCargo} to reproduce such a record for
+ * these five classes.
  *
- * <p><b>The field values in these fixtures are invented.</b> Only their structure is replicated
- * from a real capture: the generation nibble, one record of each opCode per bolus with a shared
- * bolusId, consecutive sequence numbers across the msg1/msg2/msg3 triple, and the msg3 identity
- * foodBolusSize + correctionBolusSize == totalBolusSize. These fixtures verify that parsing and
- * serialization agree and that the byte offsets do not move. They are not evidence for what any
- * individual field means.
+ * <p><b>These fixtures are entirely synthetic.</b> Both the field values and the choice of a high
+ * nibble of 1 are invented; they are not drawn from a capture, and they are not evidence that any
+ * particular pump emits this encoding, nor for what any individual field means. What they verify
+ * is narrower and self-contained: that {@code parse} and {@code buildCargo} agree byte for byte,
+ * that a nonzero high nibble survives that round trip, and that the byte offsets do not move.
  */
-public class BolusMobiGenerationHistoryLogTest {
-    private static final int MOBI = 1;
+public class BolusHeaderNibbleHistoryLogTest {
+    private static final int HIGH_NIBBLE = 1;
 
     // Bolus 2001: BLE-commanded standard bolus, food only.
     private static final String B1_MSG1 = "40100065cd1da0bb0d00d1070300000000000000000000000000";
@@ -51,69 +51,69 @@ public class BolusMobiGenerationHistoryLogTest {
     private static final String B3_COMPLETED = "1410486dcd1d7abc0d000300d307000008410000f8400000f840";
 
     @Test
-    public void testBolusRequestedMsg1Mobi() throws DecoderException {
-        // long pumpTimeSec, long sequenceNum, int bolusId, int bolusType, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int logGeneration
+    public void testBolusRequestedMsg1HighNibble() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int bolusType, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int headerHighNibble
         assertRoundTrip(B1_MSG1, new BolusRequestedMsg1HistoryLog(
-                500000000L, 900000L, 2001, 3, false, 0, 0, 0.0F, 0, MOBI));
+                500000000L, 900000L, 2001, 3, false, 0, 0, 0.0F, 0, HIGH_NIBBLE));
         assertRoundTrip(B2_MSG1, new BolusRequestedMsg1HistoryLog(
-                500001000L, 900100L, 2002, 3, true, 0, 0, 0.0F, 0, MOBI));
+                500001000L, 900100L, 2002, 3, true, 0, 0, 0.0F, 0, HIGH_NIBBLE));
         assertRoundTrip(B3_MSG1, new BolusRequestedMsg1HistoryLog(
-                500002000L, 900200L, 2003, 1, true, 45, 140, 1.5F, 6000, MOBI));
+                500002000L, 900200L, 2003, 1, true, 45, 140, 1.5F, 6000, HIGH_NIBBLE));
     }
 
     @Test
-    public void testBolusRequestedMsg2Mobi() throws DecoderException {
-        // long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int logGeneration
+    public void testBolusRequestedMsg2HighNibble() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int headerHighNibble
         assertRoundTrip(B1_MSG2, new BolusRequestedMsg2HistoryLog(
-                500000000L, 900001L, 2001, 4, 100, 0, 0, 0, 0, true, false, 1, 0, MOBI));
+                500000000L, 900001L, 2001, 4, 100, 0, 0, 0, 0, true, false, 1, 0, HIGH_NIBBLE));
         assertRoundTrip(B2_MSG2, new BolusRequestedMsg2HistoryLog(
-                500001000L, 900101L, 2002, 4, 100, 0, 0, 0, 0, true, false, 0, 0, MOBI));
+                500001000L, 900101L, 2002, 4, 100, 0, 0, 0, 0, true, false, 0, 0, HIGH_NIBBLE));
         assertRoundTrip(B3_MSG2, new BolusRequestedMsg2HistoryLog(
-                500002000L, 900201L, 2003, 0, 100, 0, 0, 30, 110, false, false, 1, 0, MOBI));
+                500002000L, 900201L, 2003, 0, 100, 0, 0, 30, 110, false, false, 1, 0, HIGH_NIBBLE));
     }
 
     @Test
-    public void testBolusRequestedMsg3Mobi() throws DecoderException {
-        // long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int logGeneration
+    public void testBolusRequestedMsg3HighNibble() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int headerHighNibble
         assertRoundTrip(B1_MSG3, new BolusRequestedMsg3HistoryLog(
-                500000000L, 900002L, 2001, 0, 3.5F, 0.0F, 3.5F, MOBI));
+                500000000L, 900002L, 2001, 0, 3.5F, 0.0F, 3.5F, HIGH_NIBBLE));
         assertRoundTrip(B2_MSG3, new BolusRequestedMsg3HistoryLog(
-                500001000L, 900102L, 2002, 0, 4.25F, 0.75F, 5.0F, MOBI));
+                500001000L, 900102L, 2002, 0, 4.25F, 0.75F, 5.0F, HIGH_NIBBLE));
         assertRoundTrip(B3_MSG3, new BolusRequestedMsg3HistoryLog(
-                500002000L, 900202L, 2003, 0, 7.5F, 0.25F, 7.75F, MOBI));
+                500002000L, 900202L, 2003, 0, 7.5F, 0.25F, 7.75F, HIGH_NIBBLE));
     }
 
     @Test
-    public void testBolusActivatedMobi() throws DecoderException {
-        // long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int logGeneration
+    public void testBolusActivatedHighNibble() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int headerHighNibble
         assertRoundTrip(B1_ACTIVATED, new BolusActivatedHistoryLog(
-                500000002L, 900008L, 2001, 1, 2.25F, 3.5F, MOBI));
+                500000002L, 900008L, 2001, 1, 2.25F, 3.5F, HIGH_NIBBLE));
         assertRoundTrip(B2_ACTIVATED, new BolusActivatedHistoryLog(
-                500001002L, 900108L, 2002, 0, 1.5F, 5.0F, MOBI));
+                500001002L, 900108L, 2002, 0, 1.5F, 5.0F, HIGH_NIBBLE));
         assertRoundTrip(B3_ACTIVATED, new BolusActivatedHistoryLog(
-                500002002L, 900208L, 2003, 1, 0.75F, 7.75F, MOBI));
+                500002002L, 900208L, 2003, 1, 0.75F, 7.75F, HIGH_NIBBLE));
     }
 
     @Test
-    public void testBolusCompletedMobi() throws DecoderException {
-        // long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested, int logGeneration
+    public void testBolusCompletedHighNibble() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested, int headerHighNibble
         assertRoundTrip(B1_COMPLETED, new BolusCompletedHistoryLog(
-                500000120L, 900018L, 3, 2001, 5.75F, 3.5F, 3.5F, MOBI));
+                500000120L, 900018L, 3, 2001, 5.75F, 3.5F, 3.5F, HIGH_NIBBLE));
         assertRoundTrip(B2_COMPLETED, new BolusCompletedHistoryLog(
-                500001120L, 900118L, 3, 2002, 6.5F, 5.0F, 5.0F, MOBI));
+                500001120L, 900118L, 3, 2002, 6.5F, 5.0F, 5.0F, HIGH_NIBBLE));
         assertRoundTrip(B3_COMPLETED, new BolusCompletedHistoryLog(
-                500002120L, 900218L, 3, 2003, 8.5F, 7.75F, 7.75F, MOBI));
+                500002120L, 900218L, 3, 2003, 8.5F, 7.75F, 7.75F, HIGH_NIBBLE));
     }
 
     /**
-     * A Mobi record must reach its class through the primary dispatch path. Before the log
-     * generation nibble was masked off in {@link HistoryLogParser}, opCode 55 with a generation of
-     * 1 was computed as typeId 4151, missed the registry, and was only recovered by the retry
-     * ladder, which logged a warning for every history log a Mobi user ever downloaded.
+     * A record must reach its class through the primary dispatch path. Before the high nibble was
+     * masked off in {@link HistoryLogParser}, opCode 55 with a high nibble of 1 was computed as
+     * typeId 4151, missed the registry, and was only recovered by the retry ladder, which logged a
+     * warning for every such record.
      */
     @Test
-    public void testMobiRecordsDispatchToTheCorrectClass() throws DecoderException {
-        assertEquals(MOBI, HistoryLogParser.parse(Hex.decodeHex(B1_MSG1)).getLogGeneration());
+    public void testHighNibbleRecordsDispatchToTheCorrectClass() throws DecoderException {
+        assertEquals(HIGH_NIBBLE, HistoryLogParser.parse(Hex.decodeHex(B1_MSG1)).getHeaderHighNibble());
 
         // The typeId the dispatcher looks up must already be the real opCode, so that these
         // records resolve on the first attempt rather than by falling through the retry ladder.
@@ -184,7 +184,7 @@ public class BolusMobiGenerationHistoryLogTest {
     }
 
     @Test
-    public void testEnumsDecodeMobiValues() throws DecoderException {
+    public void testEnumsDecodeFixtureValues() throws DecoderException {
         assertEquals(BolusRequestedMsg1HistoryLog.BolusType.REMOTE,
                 ((BolusRequestedMsg1HistoryLog) HistoryLogParser.parse(Hex.decodeHex(B1_MSG1))).getBolusType());
         assertEquals(BolusRequestedMsg1HistoryLog.BolusType.CARB,
@@ -230,7 +230,7 @@ public class BolusMobiGenerationHistoryLogTest {
 
     private static void assertRoundTrip(String rawHex, HistoryLog expected) throws DecoderException {
         HistoryLog parsed = HistoryLogMessageTester.testSingle(rawHex, expected);
-        assertEquals(MOBI, parsed.getLogGeneration());
+        assertEquals(HIGH_NIBBLE, parsed.getHeaderHighNibble());
         assertHexEquals(expected.getCargo(), parsed.getCargo());
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusMobiGenerationHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusMobiGenerationHistoryLogTest.java
@@ -1,0 +1,236 @@
+package com.jwoglom.pumpx2.pump.messages.response.historyLog;
+
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jwoglom.pumpx2.shared.Hex;
+
+import org.apache.commons.codec.DecoderException;
+import org.junit.Test;
+
+/**
+ * Round-trip coverage for the five bolus history logs as emitted by a Tandem Mobi, whose logs
+ * carry a log generation nibble of 1 in the high bits of the first two cargo bytes (so opCode 55
+ * is transmitted as {@code 37 10}, not {@code 37 00}).
+ *
+ * <p>Every existing fixture in this package comes from a t:slim X2 and carries a generation of 0,
+ * so nothing else in the suite exercises that nibble: neither the dispatch path in
+ * {@link HistoryLogParser} nor the ability of {@code buildCargo} to reproduce such a record.
+ *
+ * <p><b>The field values in these fixtures are invented.</b> Only their structure is replicated
+ * from a real capture: the generation nibble, one record of each opCode per bolus with a shared
+ * bolusId, consecutive sequence numbers across the msg1/msg2/msg3 triple, and the msg3 identity
+ * foodBolusSize + correctionBolusSize == totalBolusSize. These fixtures verify that parsing and
+ * serialization agree and that the byte offsets do not move. They are not evidence for what any
+ * individual field means.
+ */
+public class BolusMobiGenerationHistoryLogTest {
+    private static final int MOBI = 1;
+
+    // Bolus 2001: BLE-commanded standard bolus, food only.
+    private static final String B1_MSG1 = "40100065cd1da0bb0d00d1070300000000000000000000000000";
+    private static final String B1_MSG2 = "41100065cd1da1bb0d00d1070464000000000000000001000100";
+    private static final String B1_MSG3 = "42100065cd1da2bb0d00d1070000000060400000000000006040";
+    private static final String B1_ACTIVATED = "37100265cd1da8bb0d00d1070100000010400000604000000000";
+    private static final String B1_COMPLETED = "14107865cd1db2bb0d000300d1070000b8400000604000006040";
+
+    // Bolus 2002: BLE-commanded standard bolus, food plus a nonzero correction component.
+    private static final String B2_MSG1 = "4010e868cd1d04bc0d00d2070301000000000000000000000000";
+    private static final String B2_MSG2 = "4110e868cd1d05bc0d00d2070464000000000000000001000000";
+    private static final String B2_MSG3 = "4210e868cd1d06bc0d00d2070000000088400000403f0000a040";
+    private static final String B2_ACTIVATED = "3710ea68cd1d0cbc0d00d20700000000c03f0000a04000000000";
+    private static final String B2_COMPLETED = "14106069cd1d16bc0d000300d2070000d0400000a0400000a040";
+
+    // Bolus 2003: pump-entered carb bolus, exercising carbAmount/bg/isf/targetBG/carbRatio.
+    private static final String B3_MSG1 = "4010d06ccd1d68bc0d00d30701012d008c000000c03f70170000";
+    private static final String B3_MSG2 = "4110d06ccd1d69bc0d00d3070064000000001e006e0000000100";
+    private static final String B3_MSG3 = "4210d06ccd1d6abc0d00d30700000000f0400000803e0000f840";
+    private static final String B3_ACTIVATED = "3710d26ccd1d70bc0d00d30701000000403f0000f84000000000";
+    private static final String B3_COMPLETED = "1410486dcd1d7abc0d000300d307000008410000f8400000f840";
+
+    @Test
+    public void testBolusRequestedMsg1Mobi() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int bolusType, boolean correctionBolusIncluded, int carbAmount, int bg, float iob, long carbRatio, int logGeneration
+        assertRoundTrip(B1_MSG1, new BolusRequestedMsg1HistoryLog(
+                500000000L, 900000L, 2001, 3, false, 0, 0, 0.0F, 0, MOBI));
+        assertRoundTrip(B2_MSG1, new BolusRequestedMsg1HistoryLog(
+                500001000L, 900100L, 2002, 3, true, 0, 0, 0.0F, 0, MOBI));
+        assertRoundTrip(B3_MSG1, new BolusRequestedMsg1HistoryLog(
+                500002000L, 900200L, 2003, 1, true, 45, 140, 1.5F, 6000, MOBI));
+    }
+
+    @Test
+    public void testBolusRequestedMsg2Mobi() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int logGeneration
+        assertRoundTrip(B1_MSG2, new BolusRequestedMsg2HistoryLog(
+                500000000L, 900001L, 2001, 4, 100, 0, 0, 0, 0, true, false, 1, 0, MOBI));
+        assertRoundTrip(B2_MSG2, new BolusRequestedMsg2HistoryLog(
+                500001000L, 900101L, 2002, 4, 100, 0, 0, 0, 0, true, false, 0, 0, MOBI));
+        assertRoundTrip(B3_MSG2, new BolusRequestedMsg2HistoryLog(
+                500002000L, 900201L, 2003, 0, 100, 0, 0, 30, 110, false, false, 1, 0, MOBI));
+    }
+
+    @Test
+    public void testBolusRequestedMsg3Mobi() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize, int logGeneration
+        assertRoundTrip(B1_MSG3, new BolusRequestedMsg3HistoryLog(
+                500000000L, 900002L, 2001, 0, 3.5F, 0.0F, 3.5F, MOBI));
+        assertRoundTrip(B2_MSG3, new BolusRequestedMsg3HistoryLog(
+                500001000L, 900102L, 2002, 0, 4.25F, 0.75F, 5.0F, MOBI));
+        assertRoundTrip(B3_MSG3, new BolusRequestedMsg3HistoryLog(
+                500002000L, 900202L, 2003, 0, 7.5F, 0.25F, 7.75F, MOBI));
+    }
+
+    @Test
+    public void testBolusActivatedMobi() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int bolusId, int selectedIob, float iob, float bolusSize, int logGeneration
+        assertRoundTrip(B1_ACTIVATED, new BolusActivatedHistoryLog(
+                500000002L, 900008L, 2001, 1, 2.25F, 3.5F, MOBI));
+        assertRoundTrip(B2_ACTIVATED, new BolusActivatedHistoryLog(
+                500001002L, 900108L, 2002, 0, 1.5F, 5.0F, MOBI));
+        assertRoundTrip(B3_ACTIVATED, new BolusActivatedHistoryLog(
+                500002002L, 900208L, 2003, 1, 0.75F, 7.75F, MOBI));
+    }
+
+    @Test
+    public void testBolusCompletedMobi() throws DecoderException {
+        // long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested, int logGeneration
+        assertRoundTrip(B1_COMPLETED, new BolusCompletedHistoryLog(
+                500000120L, 900018L, 3, 2001, 5.75F, 3.5F, 3.5F, MOBI));
+        assertRoundTrip(B2_COMPLETED, new BolusCompletedHistoryLog(
+                500001120L, 900118L, 3, 2002, 6.5F, 5.0F, 5.0F, MOBI));
+        assertRoundTrip(B3_COMPLETED, new BolusCompletedHistoryLog(
+                500002120L, 900218L, 3, 2003, 8.5F, 7.75F, 7.75F, MOBI));
+    }
+
+    /**
+     * A Mobi record must reach its class through the primary dispatch path. Before the log
+     * generation nibble was masked off in {@link HistoryLogParser}, opCode 55 with a generation of
+     * 1 was computed as typeId 4151, missed the registry, and was only recovered by the retry
+     * ladder, which logged a warning for every history log a Mobi user ever downloaded.
+     */
+    @Test
+    public void testMobiRecordsDispatchToTheCorrectClass() throws DecoderException {
+        assertEquals(MOBI, HistoryLogParser.parse(Hex.decodeHex(B1_MSG1)).getLogGeneration());
+
+        // The typeId the dispatcher looks up must already be the real opCode, so that these
+        // records resolve on the first attempt rather than by falling through the retry ladder.
+        assertEquals(64, HistoryLogParser.typeIdOf(Hex.decodeHex(B1_MSG1)));
+        assertEquals(65, HistoryLogParser.typeIdOf(Hex.decodeHex(B1_MSG2)));
+        assertEquals(66, HistoryLogParser.typeIdOf(Hex.decodeHex(B1_MSG3)));
+        assertEquals(55, HistoryLogParser.typeIdOf(Hex.decodeHex(B1_ACTIVATED)));
+        assertEquals(20, HistoryLogParser.typeIdOf(Hex.decodeHex(B1_COMPLETED)));
+
+        assertTrue(HistoryLogParser.parse(Hex.decodeHex(B1_MSG1)) instanceof BolusRequestedMsg1HistoryLog);
+        assertTrue(HistoryLogParser.parse(Hex.decodeHex(B1_MSG2)) instanceof BolusRequestedMsg2HistoryLog);
+        assertTrue(HistoryLogParser.parse(Hex.decodeHex(B1_MSG3)) instanceof BolusRequestedMsg3HistoryLog);
+        assertTrue(HistoryLogParser.parse(Hex.decodeHex(B1_ACTIVATED)) instanceof BolusActivatedHistoryLog);
+        assertTrue(HistoryLogParser.parse(Hex.decodeHex(B1_COMPLETED)) instanceof BolusCompletedHistoryLog);
+    }
+
+    /**
+     * The five logs emitted for a single bolus must agree on the bolusId. This is the property
+     * which distinguishes the correct byte offsets from the alternatives: reading bolusId from the
+     * wrong offset makes at least one of the five disagree with the others.
+     */
+    @Test
+    public void testBolusIdAgreesAcrossAllFiveLogs() throws DecoderException {
+        assertBolusIdsAgree(2001, B1_MSG1, B1_MSG2, B1_MSG3, B1_ACTIVATED, B1_COMPLETED);
+        assertBolusIdsAgree(2002, B2_MSG1, B2_MSG2, B2_MSG3, B2_ACTIVATED, B2_COMPLETED);
+        assertBolusIdsAgree(2003, B3_MSG1, B3_MSG2, B3_MSG3, B3_ACTIVATED, B3_COMPLETED);
+    }
+
+    /**
+     * msg3 reports the food and correction components alongside the total. Compared with a
+     * tolerance, since the pump recomputes the total in float rather than copying the sum.
+     */
+    @Test
+    public void testMsg3ComponentsSumToTotal() throws DecoderException {
+        for (String hex : new String[]{B1_MSG3, B2_MSG3, B3_MSG3}) {
+            BolusRequestedMsg3HistoryLog msg3 =
+                    (BolusRequestedMsg3HistoryLog) HistoryLogParser.parse(Hex.decodeHex(hex));
+            assertEquals(msg3.getTotalBolusSize(),
+                    msg3.getFoodBolusSize() + msg3.getCorrectionBolusSize(),
+                    HistoryLog.INSULIN_FLOAT_EPSILON);
+        }
+    }
+
+    /**
+     * The dose reported by msg3, by the activated log and by the completed log must agree.
+     */
+    @Test
+    public void testDoseAgreesAcrossLogs() throws DecoderException {
+        assertDoseAgrees(B1_MSG3, B1_ACTIVATED, B1_COMPLETED);
+        assertDoseAgrees(B2_MSG3, B2_ACTIVATED, B2_COMPLETED);
+        assertDoseAgrees(B3_MSG3, B3_ACTIVATED, B3_COMPLETED);
+    }
+
+    /**
+     * byte 12 of the activated log is a field, not padding: it varies independently of the bytes
+     * around it and matches the selectedIOB reported by msg2 for the same bolus.
+     */
+    @Test
+    public void testActivatedSelectedIobIsAField() throws DecoderException {
+        BolusActivatedHistoryLog first =
+                (BolusActivatedHistoryLog) HistoryLogParser.parse(Hex.decodeHex(B1_ACTIVATED));
+        BolusActivatedHistoryLog second =
+                (BolusActivatedHistoryLog) HistoryLogParser.parse(Hex.decodeHex(B2_ACTIVATED));
+        assertNotEquals(first.getSelectedIob(), second.getSelectedIob());
+
+        assertEquals(msg2Of(B1_MSG2).getSelectedIOB(), first.getSelectedIob());
+        assertEquals(msg2Of(B2_MSG2).getSelectedIOB(), second.getSelectedIob());
+    }
+
+    @Test
+    public void testEnumsDecodeMobiValues() throws DecoderException {
+        assertEquals(BolusRequestedMsg1HistoryLog.BolusType.REMOTE,
+                ((BolusRequestedMsg1HistoryLog) HistoryLogParser.parse(Hex.decodeHex(B1_MSG1))).getBolusType());
+        assertEquals(BolusRequestedMsg1HistoryLog.BolusType.CARB,
+                ((BolusRequestedMsg1HistoryLog) HistoryLogParser.parse(Hex.decodeHex(B3_MSG1))).getBolusType());
+
+        assertEquals(BolusRequestedMsg2HistoryLog.BolusOption.BLE_STANDARD, msg2Of(B1_MSG2).getBolusOption());
+        assertEquals(BolusRequestedMsg2HistoryLog.BolusOption.STANDARD, msg2Of(B3_MSG2).getBolusOption());
+
+        assertEquals(BolusRequestedMsg2HistoryLog.SelectedIOBType.SWAN_IOB_MEAL, msg2Of(B1_MSG2).getSelectedIOBType());
+        assertEquals(BolusRequestedMsg2HistoryLog.SelectedIOBType.MUDALIAR_IOB, msg2Of(B2_MSG2).getSelectedIOBType());
+    }
+
+    private static BolusRequestedMsg2HistoryLog msg2Of(String hex) throws DecoderException {
+        return (BolusRequestedMsg2HistoryLog) HistoryLogParser.parse(Hex.decodeHex(hex));
+    }
+
+    private static void assertDoseAgrees(String msg3Hex, String activatedHex, String completedHex)
+            throws DecoderException {
+        float total = ((BolusRequestedMsg3HistoryLog) HistoryLogParser.parse(Hex.decodeHex(msg3Hex)))
+                .getTotalBolusSize();
+        float activated = ((BolusActivatedHistoryLog) HistoryLogParser.parse(Hex.decodeHex(activatedHex)))
+                .getBolusSize();
+        float requested = ((BolusCompletedHistoryLog) HistoryLogParser.parse(Hex.decodeHex(completedHex)))
+                .getInsulinRequested();
+
+        assertEquals(total, activated, HistoryLog.INSULIN_FLOAT_EPSILON);
+        assertEquals(total, requested, HistoryLog.INSULIN_FLOAT_EPSILON);
+    }
+
+    private static void assertBolusIdsAgree(int expectedBolusId, String msg1Hex, String msg2Hex,
+                                            String msg3Hex, String activatedHex, String completedHex)
+            throws DecoderException {
+        assertEquals(expectedBolusId,
+                ((BolusRequestedMsg1HistoryLog) HistoryLogParser.parse(Hex.decodeHex(msg1Hex))).getBolusId());
+        assertEquals(expectedBolusId, msg2Of(msg2Hex).getBolusId());
+        assertEquals(expectedBolusId,
+                ((BolusRequestedMsg3HistoryLog) HistoryLogParser.parse(Hex.decodeHex(msg3Hex))).getBolusId());
+        assertEquals(expectedBolusId,
+                ((BolusActivatedHistoryLog) HistoryLogParser.parse(Hex.decodeHex(activatedHex))).getBolusId());
+        assertEquals(expectedBolusId,
+                ((BolusCompletedHistoryLog) HistoryLogParser.parse(Hex.decodeHex(completedHex))).getBolusId());
+    }
+
+    private static void assertRoundTrip(String rawHex, HistoryLog expected) throws DecoderException {
+        HistoryLog parsed = HistoryLogMessageTester.testSingle(rawHex, expected);
+        assertEquals(MOBI, parsed.getLogGeneration());
+        assertHexEquals(expected.getCargo(), parsed.getCargo());
+    }
+}


### PR DESCRIPTION
## Summary

Byte offsets in `parse()` are correct for all five bolus history logs (opCodes 20, 55, 64, 65, 66) and are **unchanged**. The defects were elsewhere: a serializer that could not reproduce a record, a dispatcher that mis-read the typeId, and a missing round-trip assertion that let the first one go unnoticed.

## Fixes

**`BolusActivatedHistoryLog.buildCargo()` omitted bytes 12-13** (P0). It emitted `iob` and `bolusSize` two bytes earlier than `parse()` reads them, so it could never reproduce a real record. Byte 12 is not padding — it is `0x01` in both committed fixtures, so zero-filling does not round-trip either of them; it has to be modelled as a field. Verified: reverting only this hunk fails 3 tests, passes with it.

**`HistoryLogParser.parse()` mis-read the typeId.** It treated the top 4 bits of the first two cargo bytes as part of the id. `parse()` now applies `& 4095`, the same mask `parseBase()` already used. This also corrects dispatch for typeIds 128-255, which the previous signed-byte arithmetic resolved to `typeId+256` (~30 CGM log classes).

**`BolusRequestedMsg1HistoryLog.getBolusType()`** decoded its value as the `BolusDeliveryHistoryLog` bitmask. Changed to a scalar enum, scoped to this log only — `BolusDeliveryHistoryLog` and `LastBolusStatusAbstractResponse` are untouched. See the caveats below.

**Two unrelated already-failing tests**, same defect class: `DailyStatusHistoryLog` and `VersionsAHistoryLog` truncated their typeId to one byte in `buildCargo` (`(byte) 313` → `0x39`), so the logs they built could not be parsed back. 35 other classes have the same truncation and are left for a separate change.

Also adds a `headerHighNibble` parameter to the five `buildCargo()` signatures (default 0) so a record with nonzero high bits round-trips, ports the `options` / `selectedIOB` value maps, adds a carb-ratio accessor in grams per unit alongside the raw milliunit getter, and documents a comparison epsilon for the insulin floats.

## Evidence for the header mask

Tandem's own app does:

```java
int typeInt = readShortAsInt(copyFrom(bArr, 0, 2), ...) & 4095;
```

with `readShortAsInt` = `(b[i+1] << 8) | b[i]`, i.e. little-endian uint16 then mask 4095 — identical to `typeIdOf()` here. Their record layout also confirms the base offsets already used in this repo (type from bytes 0-2, timestamp 2-6, sequence number 6-10, then four 4-byte payload fields at 10/14/18/22), and their type table matches these opCodes.

**What the top 4 bits mean remains unknown.** Tandem's app masks them off and discards them — its `HistoryLog` model has no field for them and nothing reads them back. They are preserved here only so `buildCargo` can reproduce such a record byte for byte. No claim is made about pump model, firmware, or log format, and the accessor is named `getHeaderHighNibble()` to avoid implying one.

## Tests

`BolusActivatedHistoryLogTest` imported `assertHexEquals` and never called it — which is why the serializer bug survived. It now uses the full constructor and asserts the round trip, reproducing the bug with **no new fixtures**.

Adds `BolusHeaderNibbleHistoryLogTest`, since no bolus fixture carried a nonzero header nibble. **These fixtures are entirely synthetic** — both the values and the nibble are invented, not drawn from a capture. They verify only that `parse` and `buildCargo` agree byte for byte and that the offsets do not move. They contain no data derived from anyone's pump.

638 tests, 0 failures. Previously 627 with 4 failures (2 of them pre-existing, now fixed).

## Caveats — please read before merging

Several value maps here are **ported from tconnectsync via an external analysis and are not verified against anything in this repository**, and are marked as such in javadoc:

- `BolusRequestedMsg1HistoryLog.BolusType` — the scalar reading and its names. No committed record carries the discriminating value 3; the fixtures carry 1 and 2, which both the scalar and bitmask readings explain.
- `BolusRequestedMsg2HistoryLog.BolusOption` — no committed record exercises these at all.
- `BolusRequestedMsg2HistoryLog.SelectedIOBType` — replaces a `TODO(unknown)` with a secondhand attribution, not a confirmed one.
- `BolusActivatedHistoryLog.getSelectedIob()` — byte 12 being a field is confirmed by the fixtures; calling it `selectedIob` is an inference from it co-varying with msg2's `selectedIOB`.
- The msg1 `iob`-reads-zero note and the 1-ulp float note describe observations from that analysis, not from these fixtures.

`carbAmount` / `bg` ordering in msg1 is unconfirmed — both are zero in every committed record, so nothing here distinguishes it from the reverse.

The offset fixes, the serializer fix, the dispatch mask and the round-trip assertions do **not** depend on any of the above; they are reproducible from the fixtures in this repo and, for the mask, from the vendor decompilation.