### PR TITLE
Fix battery charge percentage calculation in DailyBasalHistoryLog

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyBasalHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyBasalHistoryLog.java
@@ -53,7 +53,7 @@ public class DailyBasalHistoryLog extends HistoryLog {
         this.lastBasalRate = Bytes.readFloat(raw, 14);
         this.iob = Bytes.readFloat(raw, 18);
         this.finalEventForDay = raw[22] == 1;
-        this.batteryChargeRaw = raw[23];
+        this.batteryChargeRaw = raw[23] & 0xFF;
         this.lipoMv = Bytes.readShort(raw, 24);
         
     }
@@ -93,22 +93,35 @@ public class DailyBasalHistoryLog extends HistoryLog {
     }
 
     /**
-     * @return TODO(confirm): whether this is the final event of the day
+     * A close-out marker on the last {@link DailyBasalHistoryLog} of a reporting period. Its usual
+     * trigger is the daily rollover just before midnight, after which {@link #getDailyTotalBasal()}
+     * resets to 0, but it has also been observed immediately before a
+     * {@link PumpingResumedHistoryLog} which ended an alarm-driven suspension, with no reset
+     * following. TODO(confirm): the exact set of triggers is unconfirmed, so this should not be
+     * relied upon as a day-boundary signal.
+     *
+     * @return whether this is the final event of the reporting period
      */
     public boolean getFinalEventForDay() {
         return finalEventForDay;
     }
 
 
+    /**
+     * @return the pump's reported battery state-of-charge, 0-100, unscaled
+     */
     public int getBatteryChargeRaw() {
         return batteryChargeRaw;
     }
 
     /**
+     * The pump reports its state of charge directly as a 0-100 percentage in this byte, so no
+     * scaling is applied.
+     *
      * @return the reported battery charge in percent
      */
     public double getBatteryChargePercent() {
-       return (100 * ((batteryChargeRaw+256.0) / 512.0));
+       return batteryChargeRaw;
     }
 
     /**

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyBasalHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyBasalHistoryLogTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertEquals;
 import com.jwoglom.pumpx2.pump.messages.MessageTester;
 import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID;
 import com.jwoglom.pumpx2.pump.messages.response.historyLog.DailyBasalHistoryLog;
+import com.jwoglom.pumpx2.shared.Hex;
 
 import java.util.Arrays;
 import org.apache.commons.codec.DecoderException;
@@ -325,5 +326,45 @@ public class DailyBasalHistoryLogTest {
         );
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
         assertEquals(Instant.parse("2022-02-18T00:16:25Z"), parsedRes.getPumpTimeSecInstant());
+    }
+
+    @Test
+    public void testBatteryChargeIsUnscaledPercent() throws DecoderException {
+        // byte 23 is the pump's state-of-charge, 0-100, with no scaling applied
+        DailyBasalHistoryLog parsedRes = (DailyBasalHistoryLog) HistoryLogMessageTester.testSingle(
+                "51000570941a0ec00200fa28b540b81e653f000000000041400f",
+                new DailyBasalHistoryLog(445935621, 180238, 5.661252F, 0.895F, 0.0F, false, 65, 3904)
+        );
+        assertEquals(65, parsedRes.getBatteryChargeRaw());
+        assertEquals(65.0, parsedRes.getBatteryChargePercent(), 0.0);
+    }
+
+    @Test
+    public void testLowBatteryChargeIsReportedAsLow() throws DecoderException {
+        // a 20% battery must be reported as 20%, not as the 53.9% the previous scaling emitted
+        DailyBasalHistoryLog expected = new DailyBasalHistoryLog(
+                445935621, 180238, 5.661252F, 0.895F, 0.0F, false, 20, 3714
+        );
+        DailyBasalHistoryLog parsedRes = (DailyBasalHistoryLog) HistoryLogMessageTester.testSingle(
+                Hex.encodeHexString(expected.getCargo()),
+                expected
+        );
+        assertEquals(20, parsedRes.getBatteryChargeRaw());
+        assertEquals(20.0, parsedRes.getBatteryChargePercent(), 0.0);
+        assertEquals(3714, parsedRes.getLipoMv());
+    }
+
+    @Test
+    public void testBatteryChargeAbove127IsReadUnsigned() throws DecoderException {
+        // guards against the signed read of byte 23; outside the pump's real 0-100 range but a
+        // signed read would return -1 rather than 255
+        DailyBasalHistoryLog expected = new DailyBasalHistoryLog(
+                445935621, 180238, 5.661252F, 0.895F, 0.0F, false, 255, 3904
+        );
+        DailyBasalHistoryLog parsedRes = (DailyBasalHistoryLog) HistoryLogMessageTester.testSingle(
+                Hex.encodeHexString(expected.getCargo()),
+                expected
+        );
+        assertEquals(255, parsedRes.getBatteryChargeRaw());
     }
 }


### PR DESCRIPTION
## Summary
Corrects the battery charge percentage calculation in `DailyBasalHistoryLog` to properly interpret the pump's battery state-of-charge value as an unscaled 0-100 percentage, rather than applying an incorrect scaling formula.

## Key Changes
- **Fixed battery charge parsing**: Changed `raw[23]` to `raw[23] & 0xFF` to ensure the byte is read as an unsigned value (0-255) rather than a signed value (-128 to 127)
- **Corrected percentage calculation**: Replaced the incorrect scaling formula `(100 * ((batteryChargeRaw+256.0) / 512.0))` with a direct return of `batteryChargeRaw`, since the pump already reports the value as a 0-100 percentage
- **Improved documentation**: Enhanced JavaDoc comments to clarify that the battery charge is reported directly as an unscaled percentage and added context about the `finalEventForDay` flag
- **Added comprehensive test coverage**: Three new test cases verify:
  - Battery charge values are correctly interpreted as unscaled percentages (65% = 65)
  - Low battery values (20%) are reported accurately without incorrect scaling
  - Values above 127 are read as unsigned (255 instead of -1)

## Implementation Details
The previous scaling formula was producing incorrect results (e.g., 20% would be reported as ~53.9%). The pump's byte 23 contains the state-of-charge directly as 0-100, requiring only an unsigned byte read with no mathematical transformation.

https://claude.ai/code/session_019gTwau1Ytaj5X4kd1Ank4Y