### PR TITLE
Fix buildCargo offset in IdpActionHistoryLog (opcode 69)

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionHistoryLog.java
@@ -56,7 +56,8 @@ public class IdpActionHistoryLog extends HistoryLog {
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) idp }, 
             new byte[]{ (byte) status }, 
-            new byte[]{ (byte) sourceIdp }, 
+            new byte[]{ (byte) sourceIdp },
+            new byte[5],
             Bytes.writeString(name, 8)));
     }
     public int getIdp() {


### PR DESCRIPTION
parse() reads the profile name as string(8) at offset 18, treating bytes 13-17 as padding, but buildCargo() was writing the name immediately after sourceIdp@12, so a record built via buildCargo() and re-parsed would decode a corrupted/truncated name. This inserts 5 zero padding bytes after sourceIdp so the name lands at offset 18, matching parse(). parse() offsets are treated as authoritative since they decode real pump data.

References https://github.com/jwoglom/pumpx2/issues/53

Companion fix in jwoglom/tandemkit on the same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_