### PR TITLE
Fix ParamChangeRemSettingsHistoryLog buildCargo offset gap (opcode 97)

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeRemSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeRemSettingsHistoryLog.java
@@ -56,10 +56,11 @@ public class ParamChangeRemSettingsHistoryLog extends HistoryLog {
             new byte[]{97, 0},
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            new byte[]{ (byte) modification }, 
-            new byte[]{ (byte) status }, 
-            Bytes.firstTwoBytesLittleEndian(lowBgThreshold), 
-            Bytes.firstTwoBytesLittleEndian(highBgThreshold), 
+            new byte[]{ (byte) modification },
+            new byte[]{ (byte) status },
+            new byte[]{0, 0},
+            Bytes.firstTwoBytesLittleEndian(lowBgThreshold),
+            Bytes.firstTwoBytesLittleEndian(highBgThreshold),
             new byte[]{ (byte) siteChangeDays }));
     }
     public int getModification() {


### PR DESCRIPTION
buildCargo() wrote lowBgThreshold immediately after status (offset 12), but parse() reads lowBgThreshold at offset 14, leaving bytes 12-13 unaccounted for. This inserts a 2-byte zero pad after status so buildCargo's layout matches parse's authoritative offsets.

References https://github.com/jwoglom/pumpx2/issues/58

Companion fix: https://github.com/jwoglom/TandemKit (same branch name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_