### PR TITLE
Fix buildCargo offset in IdpBolusHistoryLog (opcode 70)

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpBolusHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpBolusHistoryLog.java
@@ -60,8 +60,9 @@ public class IdpBolusHistoryLog extends HistoryLog {
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) idp }, 
             new byte[]{ (byte) modification }, 
-            new byte[]{ (byte) bolusStatus }, 
-            Bytes.firstTwoBytesLittleEndian(insulinDuration), 
+            new byte[]{ (byte) bolusStatus },
+            new byte[1],
+            Bytes.firstTwoBytesLittleEndian(insulinDuration),
             Bytes.firstTwoBytesLittleEndian(maxBolusSize), 
             new byte[]{ (byte) bolusEntryType }));
     }


### PR DESCRIPTION
parse() reads insulinDuration@14, maxBolusSize@16, and bolusEntryType@18, skipping a padding byte at offset 13, but buildCargo() was writing those fields contiguously starting right after bolusStatus@12. This inserts 1 zero padding byte after bolusStatus so serialized cargo matches parse()'s offsets. parse() offsets are treated as authoritative since they decode real pump data.

References https://github.com/jwoglom/pumpx2/issues/54

Companion fix in jwoglom/tandemkit on the same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_