### PR TITLE
Fix CgmDataSampleHistoryLog buildCargo offset gap (opcode 151)

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataSampleHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataSampleHistoryLog.java
@@ -50,7 +50,8 @@ public class CgmDataSampleHistoryLog extends HistoryLog {
             new byte[]{-105, 0}, // (byte) 151
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            Bytes.firstTwoBytesLittleEndian(status), 
+            Bytes.firstTwoBytesLittleEndian(status),
+            new byte[7],
             Bytes.firstTwoBytesLittleEndian(value)));
     }
     public int getStatus() {


### PR DESCRIPTION
buildCargo() wrote value immediately after status (offset 12), but parse() reads value at offset 19. This inserts a 7-byte zero pad after status so buildCargo's layout matches parse's authoritative offsets. This class is annotated as unused in current firmware, so practical impact is low.

References https://github.com/jwoglom/pumpx2/issues/60

Companion fix: https://github.com/jwoglom/TandemKit (same branch name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_