### PR TITLE
Fix BasalDeliveryHistoryLog buildCargo offset gap (opcode 279)

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLog.java
@@ -57,8 +57,9 @@ public class BasalDeliveryHistoryLog extends HistoryLog {
             new byte[]{23, 0}, // (byte) 279
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
-            Bytes.firstTwoBytesLittleEndian(commandedRateSource), 
-            Bytes.firstTwoBytesLittleEndian(commandedRate), 
+            Bytes.firstTwoBytesLittleEndian(commandedRateSource),
+            new byte[2],
+            Bytes.firstTwoBytesLittleEndian(commandedRate),
             Bytes.firstTwoBytesLittleEndian(profileBasalRate), 
             Bytes.firstTwoBytesLittleEndian(algorithmRate), 
             Bytes.firstTwoBytesLittleEndian(tempRate)));


### PR DESCRIPTION
buildCargo() wrote the five uint16 fields contiguously starting at offset 10, but parse() reads commandedRate/profileBasalRate/algorithmRate/tempRate at offsets 14/16/18/20 respectively, leaving a 2-byte gap after commandedRateSource. This inserts a 2-byte zero pad after commandedRateSource so buildCargo's layout matches parse's authoritative offsets. This only addresses the internal buildCargo/parse self-inconsistency noted in the issue; it does not touch the separate Java-vs-Python field-order question.

References https://github.com/jwoglom/pumpx2/issues/77

Companion fix: https://github.com/jwoglom/TandemKit (same branch name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_