### PR TITLE
Add history log tests from captured pump records: CGM

### DIFF
--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckDexHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckDexHistoryLogTest.java
@@ -1,0 +1,36 @@
+package com.jwoglom.pumpx2.pump.messages.response.historyLog;
+
+import org.apache.commons.codec.DecoderException;
+import org.junit.Test;
+
+public class CgmAlertAckDexHistoryLogTest {
+    @Test
+    public void testCgmAlertAckDexHistoryLog1() throws DecoderException {
+        CgmAlertAckDexHistoryLog expected = new CgmAlertAckDexHistoryLog(
+            // long pumpTimeSec, long sequenceNum, long alertId
+            580750504L, 489859L, 770L
+        );
+
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        HistoryLogMessageTester.testSingle(
+                "7311a88c9d228379070002030000000000000000000000000000",
+                expected
+        );
+    }
+
+    @Test
+    public void testCgmAlertAckDexHistoryLog2() throws DecoderException {
+        CgmAlertAckDexHistoryLog expected = new CgmAlertAckDexHistoryLog(
+            // long pumpTimeSec, long sequenceNum, long alertId
+            579789268L, 449784L, 800L
+        );
+
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // this sample also has a nonzero byte at payload offset 4 (raw byte 14 = 0x01) which
+        // CgmAlertAckDexHistoryLog.parse() does not read; see report for details
+        HistoryLogMessageTester.testSingle(
+                "7311d4e18e22f8dc060020030000010000000000000000000000",
+                expected
+        );
+    }
+}

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedDexHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedDexHistoryLogTest.java
@@ -1,0 +1,34 @@
+package com.jwoglom.pumpx2.pump.messages.response.historyLog;
+
+import org.apache.commons.codec.DecoderException;
+import org.junit.Test;
+
+public class CgmAlertActivatedDexHistoryLogTest {
+    @Test
+    public void testCgmAlertActivatedDexHistoryLog1() throws DecoderException {
+        CgmAlertActivatedDexHistoryLog expected = new CgmAlertActivatedDexHistoryLog(
+            // long pumpTimeSec, long sequenceNum, long alertId
+            580770552L, 490757L, 770L
+        );
+
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        HistoryLogMessageTester.testSingle(
+                "7111f8da9d22057d07000203000014210000d000000000004843",
+                expected
+        );
+    }
+
+    @Test
+    public void testCgmAlertActivatedDexHistoryLog2() throws DecoderException {
+        CgmAlertActivatedDexHistoryLog expected = new CgmAlertActivatedDexHistoryLog(
+            // long pumpTimeSec, long sequenceNum, long alertId
+            580720459L, 488615L, 782L
+        );
+
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        HistoryLogMessageTester.testSingle(
+                "71114b179d22a77407000e0300000e2100001900000000406544",
+                expected
+        );
+    }
+}

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedDexHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedDexHistoryLogTest.java
@@ -1,0 +1,34 @@
+package com.jwoglom.pumpx2.pump.messages.response.historyLog;
+
+import org.apache.commons.codec.DecoderException;
+import org.junit.Test;
+
+public class CgmAlertClearedDexHistoryLogTest {
+    @Test
+    public void testCgmAlertClearedDexHistoryLog1() throws DecoderException {
+        CgmAlertClearedDexHistoryLog expected = new CgmAlertClearedDexHistoryLog(
+            // long pumpTimeSec, long sequenceNum, long alertId
+            580777763L, 491134L, 770L
+        );
+
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        HistoryLogMessageTester.testSingle(
+                "721123f79d227e7e070002030000000000000000000000000000",
+                expected
+        );
+    }
+
+    @Test
+    public void testCgmAlertClearedDexHistoryLog2() throws DecoderException {
+        CgmAlertClearedDexHistoryLog expected = new CgmAlertClearedDexHistoryLog(
+            // long pumpTimeSec, long sequenceNum, long alertId
+            580720754L, 488623L, 782L
+        );
+
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        HistoryLogMessageTester.testSingle(
+                "721172189d22af7407000e030000000000000000000000000000",
+                expected
+        );
+    }
+}


### PR DESCRIPTION
Adds unit tests asserting that raw CGM alert history-log records observed from a real pump parse correctly. Byte sequences are copied verbatim from a captured pump BLE session.

Classes covered:
- `CgmAlertActivatedDexHistoryLog` (opcode 369)
- `CgmAlertClearedDexHistoryLog` (opcode 370)
- `CgmAlertAckDexHistoryLog` (opcode 371)

`CgmPairingCodeG7HistoryLog` (opcode 395) is not included — see PR comment for why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_