### PR TITLE
Add history log tests from captured pump records: Control-IQ and basal delivery

### DIFF
--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLogTest.java
@@ -1,27 +1,39 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
-import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
-
-import com.jwoglom.pumpx2.pump.messages.MessageTester;
-import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID;
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.BasalDeliveryHistoryLog;
-
-import java.util.Arrays;
 import org.apache.commons.codec.DecoderException;
-import org.junit.Ignore;
 import org.junit.Test;
-@Ignore("needs historyLog sample")
+
 public class BasalDeliveryHistoryLogTest {
     @Test
-    public void testBasalDeliveryHistoryLog() throws DecoderException {
+    public void testBasalDeliveryHistoryLog1() throws DecoderException {
+        // algorithmRate=65535 (0xffff) here represents "n/a" (Control-IQ not commanding a rate).
+        // Byte 12-13 of this capture (0x0003 LE = 3) is unparsed: parse() reads commandedRateSource
+        // as a 2-byte short at offset 10 (bytes 10-11), then jumps straight to commandedRate at
+        // offset 14, so bytes 12-13 are skipped and never asserted here.
         BasalDeliveryHistoryLog expected = new BasalDeliveryHistoryLog(
-            // int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            580777627L, 491072L, 0, 0, 1000, 65535, 65535
         );
 
         BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
-                "xxxx",
+                "17119bf69d22407e0700000003000000e803ffffffff00000000",
                 expected
         );
-        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+    }
+
+    @Test
+    public void testBasalDeliveryHistoryLog2() throws DecoderException {
+        // Byte 12-13 of this capture (0x0003 LE = 3) is unparsed, same as above.
+        BasalDeliveryHistoryLog expected = new BasalDeliveryHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            580769524L, 490724L, 3, 1000, 1000, 1000, 65535
+        );
+
+        BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "1711f4d69d22e47c070003000300e803e803e803ffff00000000",
+                expected
+        );
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLogTest.java
@@ -1,27 +1,40 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
-import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
-
-import com.jwoglom.pumpx2.pump.messages.MessageTester;
-import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID;
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.ControlIQPcmChangeHistoryLog;
-
-import java.util.Arrays;
 import org.apache.commons.codec.DecoderException;
-import org.junit.Ignore;
 import org.junit.Test;
-@Ignore("needs historyLog sample")
+
 public class ControlIQPcmChangeHistoryLogTest {
     @Test
-    public void testControlIQPcmChangeHistoryLog() throws DecoderException {
+    public void testControlIQPcmChangeHistoryLog1() throws DecoderException {
         ControlIQPcmChangeHistoryLog expected = new ControlIQPcmChangeHistoryLog(
-            // int currentPcm, int previousPcm
+            // long pumpTimeSec, long sequenceNum, int currentPcm, int previousPcm
+            580773244L, 490889L, 0, 3
         );
+        // the constructor above only stores the raw currentPcmId/previousPcmId; re-parse expected's
+        // own cargo so its derived currentPcm/previousPcm enums are populated for verboseToString comparison
+        expected.parse(expected.getCargo());
 
         ControlIQPcmChangeHistoryLog parsedRes = (ControlIQPcmChangeHistoryLog) HistoryLogMessageTester.testSingle(
-                "xxxx",
+                "e6107ce59d22897d070000030101010101000000000000000000",
                 expected
         );
-        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+    }
+
+    @Test
+    public void testControlIQPcmChangeHistoryLog2() throws DecoderException {
+        ControlIQPcmChangeHistoryLog expected = new ControlIQPcmChangeHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int currentPcm, int previousPcm
+            580720759L, 488634L, 3, 2
+        );
+        // the constructor above only stores the raw currentPcmId/previousPcmId; re-parse expected's
+        // own cargo so its derived currentPcm/previousPcm enums are populated for verboseToString comparison
+        expected.parse(expected.getCargo());
+
+        ControlIQPcmChangeHistoryLog parsedRes = (ControlIQPcmChangeHistoryLog) HistoryLogMessageTester.testSingle(
+                "e61077189d22ba74070003020001010101000000000000000000",
+                expected
+        );
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQUserModeChangeHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQUserModeChangeHistoryLogTest.java
@@ -1,27 +1,36 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
-import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
-
-import com.jwoglom.pumpx2.pump.messages.MessageTester;
-import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID;
-import com.jwoglom.pumpx2.pump.messages.response.historyLog.ControlIQUserModeChangeHistoryLog;
-
-import java.util.Arrays;
 import org.apache.commons.codec.DecoderException;
-import org.junit.Ignore;
 import org.junit.Test;
-@Ignore("needs historyLog sample")
+
 public class ControlIQUserModeChangeHistoryLogTest {
     @Test
-    public void testControlIQUserModeChangeHistoryLog() throws DecoderException {
+    public void testControlIQUserModeChangeHistoryLog1() throws DecoderException {
         ControlIQUserModeChangeHistoryLog expected = new ControlIQUserModeChangeHistoryLog(
-            // int currentUserMode, int previousUserMode
+            // long pumpTimeSec, long sequenceNum, int currentUserMode, int previousUserMode
+            579954015L, 456965L, 1, 2
         );
 
+        // Byte 12 of this capture (0x04) carries a requestedAction value which parse() does not read.
         ControlIQUserModeChangeHistoryLog parsedRes = (ControlIQUserModeChangeHistoryLog) HistoryLogMessageTester.testSingle(
-                "xxxx",
+                "e5105f65912205f9060001020400000100000000000000000000",
                 expected
         );
-        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+    }
+
+    @Test
+    public void testControlIQUserModeChangeHistoryLog2() throws DecoderException {
+        ControlIQUserModeChangeHistoryLog expected = new ControlIQUserModeChangeHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int currentUserMode, int previousUserMode
+            579953995L, 456952L, 0, 1
+        );
+
+        // Byte 12 of this capture (0x02) carries a requestedAction value which parse() does not read.
+        ControlIQUserModeChangeHistoryLog parsedRes = (ControlIQUserModeChangeHistoryLog) HistoryLogMessageTester.testSingle(
+                "e5104b659122f8f8060000010200010100000000000000000000",
+                expected
+        );
+        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
     }
 }


### PR DESCRIPTION
Adds unit tests asserting real-pump-captured history log records parse correctly; bytes are copied verbatim from BLE captures.

Classes covered:
- `ControlIQUserModeChangeHistoryLog` (2 tests)
- `ControlIQPcmChangeHistoryLog` (2 tests)
- `BasalDeliveryHistoryLog` (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_