### PR TITLE
Register six missing history log classes in HistoryLogParser

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogParser.java
@@ -97,7 +97,13 @@ public class HistoryLogParser {
         AlertClearedHistoryLog.class,
         VersionInfoHistoryLog.class,
         UpdateStatusHistoryLog.class,
-        VersionsAHistoryLog.class
+        VersionsAHistoryLog.class,
+        AlarmAckHistoryLog.class,
+        AlertAckHistoryLog.class,
+        ReminderActivatedHistoryLog.class,
+        ReminderDismissedHistoryLog.class,
+        CgmPairingCodeG7HistoryLog.class,
+        TipsErrorHistoryLog.class
         // MESSAGES_END
     );
 


### PR DESCRIPTION
`AlarmAckHistoryLog` (opcode 8), `AlertAckHistoryLog` (27), `ReminderActivatedHistoryLog` (25), `ReminderDismissedHistoryLog` (29), `CgmPairingCodeG7HistoryLog` (395), and `TipsErrorHistoryLog` (419) are fully implemented but were absent from `HistoryLogParser.LOG_MESSAGE_TYPES`, so real records of these types were dispatched to `UnknownHistoryLog`. This was found while writing tests against captured pump records (#112, #113, #115). No opcode collisions with already-registered classes; `:messages:test` passes.

After this merges, the four alert/reminder tests in #115 that bypass the registry (they call `parse()` directly with a comment noting the gap) can be simplified to the standard `HistoryLogMessageTester.testSingle` path, and `CgmPairingCodeG7HistoryLog`/`TipsErrorHistoryLog` tests become writable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_