### PR TITLE
Support header high nibble in built history logs; restore cargo round-trip assertions

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
@@ -125,6 +125,21 @@ public abstract class HistoryLog {
         return this.cargo;
     }
 
+    /**
+     * Rewrites the already-built cargo's header high nibble (see {@link #getHeaderHighNibble()})
+     * in place, so a constructor-built object can reproduce a captured record byte for byte
+     * when that record carries a nonzero value there.
+     *
+     * @param headerHighNibble the top 4 bits to write, 0-15
+     * @return this, for chaining onto a builder/constructor call
+     */
+    public HistoryLog withHeaderHighNibble(int headerHighNibble) {
+        Validate.isTrue(headerHighNibble >= 0 && headerHighNibble <= 15, "headerHighNibble must be 0-15");
+        Validate.isTrue(cargo != null && cargo.length >= 2, "cargo must be built before withHeaderHighNibble is called");
+        cargo[1] = (byte) ((cargo[1] & 0x0F) | ((headerHighNibble & 0x0F) << 4));
+        return this;
+    }
+
     public String toString() {
         return JavaHelpers.autoToString(this, new HashSet<>());
     }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLogTest.java
@@ -19,7 +19,7 @@ public class BasalDeliveryHistoryLogTest {
                 "17119bf69d22407e0700000003000000e803ffffffff00000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 12-13 carry unparsed data (0x0003) that buildCargo zero-fills
     }
 
     @Test
@@ -34,6 +34,6 @@ public class BasalDeliveryHistoryLogTest {
                 "1711f4d69d22e47c070003000300e803e803e803ffff00000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 12-13 carry unparsed data (0x0003) that buildCargo zero-fills
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CannulaFilledHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CannulaFilledHistoryLogTest.java
@@ -1,34 +1,36 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
 public class CannulaFilledHistoryLogTest {
     @Test
     public void testCannulaFilledHistoryLog1() throws DecoderException {
-        CannulaFilledHistoryLog expected = new CannulaFilledHistoryLog(
+        CannulaFilledHistoryLog expected = (CannulaFilledHistoryLog) new CannulaFilledHistoryLog(
             // long pumpTimeSec, long sequenceNum, float primeSize, long completionStatus
             580601541L, 483933L, 0.3F, 3L
-        );
+        ).withHeaderHighNibble(1);
 
         CannulaFilledHistoryLog parsedRes = (CannulaFilledHistoryLog) HistoryLogMessageTester.testSingle(
                 "3d10c5469b225d6207009a99993e030000000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testCannulaFilledHistoryLog2() throws DecoderException {
-        CannulaFilledHistoryLog expected = new CannulaFilledHistoryLog(
+        CannulaFilledHistoryLog expected = (CannulaFilledHistoryLog) new CannulaFilledHistoryLog(
             // long pumpTimeSec, long sequenceNum, float primeSize, long completionStatus
             579744849L, 448176L, 0.3F, 3L
-        );
+        ).withHeaderHighNibble(1);
 
         CannulaFilledHistoryLog parsedRes = (CannulaFilledHistoryLog) HistoryLogMessageTester.testSingle(
                 "3d1051348e22b0d606009a99993e030000000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckDexHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckDexHistoryLogTest.java
@@ -11,7 +11,8 @@ public class CgmAlertAckDexHistoryLogTest {
             580750504L, 489859L, 770L
         );
 
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: buildCargo hardcodes byte 1's low nibble to 0, but typeId 371
+        // needs 1 there (bits 8-11 of the 12-bit typeId), independent of the header high nibble
         HistoryLogMessageTester.testSingle(
                 "7311a88c9d228379070002030000000000000000000000000000",
                 expected
@@ -25,7 +26,8 @@ public class CgmAlertAckDexHistoryLogTest {
             579789268L, 449784L, 800L
         );
 
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: buildCargo hardcodes byte 1's low nibble to 0, but typeId 371
+        // needs 1 there (bits 8-11 of the 12-bit typeId), independent of the header high nibble;
         // this sample also has a nonzero byte at payload offset 4 (raw byte 14 = 0x01) which
         // CgmAlertAckDexHistoryLog.parse() does not read; see report for details
         HistoryLogMessageTester.testSingle(

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedDexHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedDexHistoryLogTest.java
@@ -11,7 +11,9 @@ public class CgmAlertActivatedDexHistoryLogTest {
             580770552L, 490757L, 770L
         );
 
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: buildCargo hardcodes byte 1's low nibble to 0, but typeId 369
+        // needs 1 there (bits 8-11 of the 12-bit typeId), independent of the header high nibble;
+        // bytes 14-15, 18, and 24-25 also carry unparsed nonzero data that buildCargo zero-fills
         HistoryLogMessageTester.testSingle(
                 "7111f8da9d22057d07000203000014210000d000000000004843",
                 expected
@@ -25,7 +27,9 @@ public class CgmAlertActivatedDexHistoryLogTest {
             580720459L, 488615L, 782L
         );
 
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: buildCargo hardcodes byte 1's low nibble to 0, but typeId 369
+        // needs 1 there (bits 8-11 of the 12-bit typeId), independent of the header high nibble;
+        // bytes 14-15, 18, and 23-25 also carry unparsed nonzero data that buildCargo zero-fills
         HistoryLogMessageTester.testSingle(
                 "71114b179d22a77407000e0300000e2100001900000000406544",
                 expected

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedDexHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedDexHistoryLogTest.java
@@ -11,7 +11,8 @@ public class CgmAlertClearedDexHistoryLogTest {
             580777763L, 491134L, 770L
         );
 
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: buildCargo hardcodes byte 1's low nibble to 0, but typeId 370
+        // needs 1 there (bits 8-11 of the 12-bit typeId), independent of the header high nibble
         HistoryLogMessageTester.testSingle(
                 "721123f79d227e7e070002030000000000000000000000000000",
                 expected
@@ -25,7 +26,8 @@ public class CgmAlertClearedDexHistoryLogTest {
             580720754L, 488623L, 782L
         );
 
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: buildCargo hardcodes byte 1's low nibble to 0, but typeId 370
+        // needs 1 there (bits 8-11 of the 12-bit typeId), independent of the header high nibble
         HistoryLogMessageTester.testSingle(
                 "721172189d22af7407000e030000000000000000000000000000",
                 expected

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLogTest.java
@@ -18,7 +18,8 @@ public class ControlIQPcmChangeHistoryLogTest {
                 "e6107ce59d22897d070000030101010101000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 12-16 carry unparsed data (0x01 each) that buildCargo
+        // zero-fills
     }
 
     @Test
@@ -35,6 +36,7 @@ public class ControlIQPcmChangeHistoryLogTest {
                 "e61077189d22ba74070003020001010101000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 13-16 carry unparsed data (0x01 each) that buildCargo
+        // zero-fills
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQUserModeChangeHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQUserModeChangeHistoryLogTest.java
@@ -16,7 +16,8 @@ public class ControlIQUserModeChangeHistoryLogTest {
                 "e5105f65912205f9060001020400000100000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 12 (0x04) and 15 (0x01) carry unparsed data that buildCargo
+        // zero-fills
     }
 
     @Test
@@ -31,6 +32,7 @@ public class ControlIQUserModeChangeHistoryLogTest {
                 "e5104b659122f8f8060000010200010100000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 12 (0x02), 14 (0x01), and 15 (0x01) carry unparsed data
+        // that buildCargo zero-fills
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/NewDayHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/NewDayHistoryLogTest.java
@@ -1,34 +1,36 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
 public class NewDayHistoryLogTest {
     @Test
     public void testNewDayHistoryLog1() throws DecoderException {
-        NewDayHistoryLog expected = new NewDayHistoryLog(
+        NewDayHistoryLog expected = (NewDayHistoryLog) new NewDayHistoryLog(
             // long pumpTimeSec, long sequenceNum, float commandedBasalRate, long featuresBitmask, long featureBitmaskIndex
             580521600L, 480602L, 3.4590001F, 1986368786L, 93L
-        );
+        ).withHeaderHighNibble(1);
 
         NewDayHistoryLog parsedRes = (NewDayHistoryLog) HistoryLogMessageTester.testSingle(
                 "5a10800e9a225a55070042605d40129565765d00000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testNewDayHistoryLog2() throws DecoderException {
-        NewDayHistoryLog expected = new NewDayHistoryLog(
+        NewDayHistoryLog expected = (NewDayHistoryLog) new NewDayHistoryLog(
             // long pumpTimeSec, long sequenceNum, float commandedBasalRate, long featuresBitmask, long featureBitmaskIndex
             580694400L, 487757L, 0.0F, 1986368786L, 93L
-        );
+        ).withHeaderHighNibble(1);
 
         NewDayHistoryLog parsedRes = (NewDayHistoryLog) HistoryLogMessageTester.testSingle(
                 "5a1080b19c224d71070000000000129565765d00000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeRemSettingsHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeRemSettingsHistoryLogTest.java
@@ -1,5 +1,7 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
@@ -9,29 +11,29 @@ public class ParamChangeRemSettingsHistoryLogTest {
     // carry meaningful unparsed data in this capture.
     @Test
     public void testParamChangeRemSettingsHistoryLog1() throws DecoderException {
-        ParamChangeRemSettingsHistoryLog expected = new ParamChangeRemSettingsHistoryLog(
+        ParamChangeRemSettingsHistoryLog expected = (ParamChangeRemSettingsHistoryLog) new ParamChangeRemSettingsHistoryLog(
             // long pumpTimeSec, long sequenceNum, int modification, int status, int lowBgThreshold, int highBgThreshold, int siteChangeDays
             580601544L, 483934L, 2, 4, 70, 200, 2
-        );
+        ).withHeaderHighNibble(1);
 
         ParamChangeRemSettingsHistoryLog parsedRes = (ParamChangeRemSettingsHistoryLog) HistoryLogMessageTester.testSingle(
                 "6110c8469b225e620700020400004600c8000200000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testParamChangeRemSettingsHistoryLog2() throws DecoderException {
-        ParamChangeRemSettingsHistoryLog expected = new ParamChangeRemSettingsHistoryLog(
+        ParamChangeRemSettingsHistoryLog expected = (ParamChangeRemSettingsHistoryLog) new ParamChangeRemSettingsHistoryLog(
             // long pumpTimeSec, long sequenceNum, int modification, int status, int lowBgThreshold, int highBgThreshold, int siteChangeDays
             579744851L, 448177L, 2, 4, 70, 200, 2
-        );
+        ).withHeaderHighNibble(1);
 
         ParamChangeRemSettingsHistoryLog parsedRes = (ParamChangeRemSettingsHistoryLog) HistoryLogMessageTester.testSingle(
                 "611053348e22b1d60600020400004600c8000200000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeReminderHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeReminderHistoryLogTest.java
@@ -1,34 +1,36 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
 public class ParamChangeReminderHistoryLogTest {
     @Test
     public void testParamChangeReminderHistoryLog1() throws DecoderException {
-        ParamChangeReminderHistoryLog expected = new ParamChangeReminderHistoryLog(
+        ParamChangeReminderHistoryLog expected = (ParamChangeReminderHistoryLog) new ParamChangeReminderHistoryLog(
             // long pumpTimeSec, long sequenceNum, int modification, int reminderId, int status, int enable, long frequencyMinutes, int startTime, int endTime, int activeDays
             580601544L, 483936L, 1, 2, 3, 1, 1380L, 0, 0, 0
-        );
+        ).withHeaderHighNibble(1);
 
         ParamChangeReminderHistoryLog parsedRes = (ParamChangeReminderHistoryLog) HistoryLogMessageTester.testSingle(
                 "6010c8469b226062070001020301640500000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testParamChangeReminderHistoryLog2() throws DecoderException {
-        ParamChangeReminderHistoryLog expected = new ParamChangeReminderHistoryLog(
+        ParamChangeReminderHistoryLog expected = (ParamChangeReminderHistoryLog) new ParamChangeReminderHistoryLog(
             // long pumpTimeSec, long sequenceNum, int modification, int reminderId, int status, int enable, long frequencyMinutes, int startTime, int endTime, int activeDays
             580601544L, 483935L, 0, 2, 3, 1, 1380L, 0, 0, 0
-        );
+        ).withHeaderHighNibble(1);
 
         ParamChangeReminderHistoryLog parsedRes = (ParamChangeReminderHistoryLog) HistoryLogMessageTester.testSingle(
                 "6010c8469b225f62070000020301640500000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ShelfModeHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ShelfModeHistoryLogTest.java
@@ -1,20 +1,22 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
 public class ShelfModeHistoryLogTest {
     @Test
     public void testShelfModeHistoryLog1() throws DecoderException {
-        ShelfModeHistoryLog expected = new ShelfModeHistoryLog(
+        ShelfModeHistoryLog expected = (ShelfModeHistoryLog) new ShelfModeHistoryLog(
             // long pumpTimeSec, long sequenceNum, long msecSinceReset, int lipoIbc, int lipoAbc, int lipoCurrent, long lipoRemCap, long lipoMv
             580777764L, 491136L, 1078644679L, 0, 0, 23130, 130L, 4176L
-        );
+        ).withHeaderHighNibble(1);
 
         ShelfModeHistoryLog parsedRes = (ShelfModeHistoryLog) HistoryLogMessageTester.testSingle(
                 "351024f79d22807e0700c7cf4a4000005a5a8200000050100000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateActivatedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateActivatedHistoryLogTest.java
@@ -15,6 +15,8 @@ public class TempRateActivatedHistoryLogTest {
                 "0210c6b38e221fdb06000000484200badb4a0200150000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 18-19 carry unparsed data (0x0002 LE) that buildCargo does
+        // not reproduce; buildCargo also writes tempRateId at offset 18 rather than offset 20,
+        // where parse() actually reads it
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateCompletedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateCompletedHistoryLogTest.java
@@ -15,6 +15,8 @@ public class TempRateCompletedHistoryLogTest {
                 "0f10eecf8e2246dc060003001500000000000000000000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        // no cargo round-trip: bytes 10-11 carry unparsed data (0x0003 LE) that buildCargo does
+        // not reproduce; buildCargo also writes tempRateId at offset 10 rather than offset 12,
+        // where parse() actually reads it
     }
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TubingFilledHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TubingFilledHistoryLogTest.java
@@ -1,5 +1,7 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
+import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
@@ -10,29 +12,29 @@ public class TubingFilledHistoryLogTest {
     // sample. Left in verbatim per the capture rather than assumed a bug.
     @Test
     public void testTubingFilledHistoryLog1() throws DecoderException {
-        TubingFilledHistoryLog expected = new TubingFilledHistoryLog(
+        TubingFilledHistoryLog expected = (TubingFilledHistoryLog) new TubingFilledHistoryLog(
             // long pumpTimeSec, long sequenceNum, float primeSize, long completionStatus, long position
             580734269L, 489155L, -1.0F, 3L, 662652L
-        );
+        ).withHeaderHighNibble(1);
 
         TubingFilledHistoryLog parsedRes = (TubingFilledHistoryLog) HistoryLogMessageTester.testSingle(
                 "3f103d4d9d22c3760700000080bf030000007c1c0a0000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 
     @Test
     public void testTubingFilledHistoryLog2() throws DecoderException {
-        TubingFilledHistoryLog expected = new TubingFilledHistoryLog(
+        TubingFilledHistoryLog expected = (TubingFilledHistoryLog) new TubingFilledHistoryLog(
             // long pumpTimeSec, long sequenceNum, float primeSize, long completionStatus, long position
             579743459L, 448074L, -1.0F, 3L, 547509L
-        );
+        ).withHeaderHighNibble(1);
 
         TubingFilledHistoryLog parsedRes = (TubingFilledHistoryLog) HistoryLogMessageTester.testSingle(
                 "3f10e32e8e224ad60600000080bf03000000b55a080000000000",
                 expected
         );
-        // no cargo round-trip: capture carries header high nibble 1 which buildCargo does not reproduce
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }


### PR DESCRIPTION
## Summary

Adds `HistoryLog.withHeaderHighNibble(int)`, which rewrites an already-built cargo's header high nibble (see `HistoryLog.getHeaderHighNibble()`) in place, so a constructor-built object can reproduce a captured record byte for byte when that record carries a nonzero value there.

Goes through every capture-based test merged in #112, #113, and #114 that had omitted the `assertHexEquals` cargo round-trip assertion with a "capture carries header high nibble 1" comment, and checks whether `buildCargo` now reproduces the raw capture once the nibble is applied:

- **Round-trip restored** (added `.withHeaderHighNibble(1)` + `assertHexEquals`): `CannulaFilledHistoryLog`, `NewDayHistoryLog`, `TubingFilledHistoryLog`, `ShelfModeHistoryLog`, `ParamChangeReminderHistoryLog`, `ParamChangeRemSettingsHistoryLog`.
- **Round-trip still not possible** (comment updated to name the real blocker instead of the header nibble): `BasalDeliveryHistoryLog`, `ControlIQPcmChangeHistoryLog`, `ControlIQUserModeChangeHistoryLog`, `TempRateActivatedHistoryLog`, `TempRateCompletedHistoryLog` all have genuinely unparsed nonzero payload bytes that `buildCargo` zero-fills. The three Dex CGM alert classes (`CgmAlertActivatedDexHistoryLog`, `CgmAlertClearedDexHistoryLog`, `CgmAlertAckDexHistoryLog`, opcodes 369-371) have a separate pre-existing `buildCargo` bug: it hardcodes the header byte's low nibble to 0, but opcodes above 255 need their own high bits encoded there — unrelated to the header high nibble this PR addresses, and left as-is per the no-other-production-changes scope of this fix.

No raw hex strings were changed and no asserted fields were changed — only the round-trip assertion and its surrounding comment.

## Test plan
- [x] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :messages:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_