### PR TITLE
Use typeIdBytes for history log cargo headers; fix truncated typeIds above 255

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AAExerciseChoiceChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AAExerciseChoiceChangeHistoryLog.java
@@ -34,7 +34,7 @@ public class AAExerciseChoiceChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{63, 1}, // typeId=319 (256+63)
+            HistoryLog.typeIdBytes(319, 0), // typeId=319 (256+63)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AAExerciseTimeChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AAExerciseTimeChangeHistoryLog.java
@@ -34,7 +34,7 @@ public class AAExerciseTimeChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{62, 1}, // typeId=318 (256+62)
+            HistoryLog.typeIdBytes(318, 0), // typeId=318 (256+62)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AATdiEstChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AATdiEstChangeHistoryLog.java
@@ -34,7 +34,7 @@ public class AATdiEstChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{76, 1}, // typeId=332 (256+76)
+            HistoryLog.typeIdBytes(332, 0), // typeId=332 (256+76)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaAutoBolusRejectedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaAutoBolusRejectedHistoryLog.java
@@ -32,7 +32,7 @@ public class AaAutoBolusRejectedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{32, 1}, // 288 = 256 + 32
+            HistoryLog.typeIdBytes(288, 0), // 288 = 256 + 32
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaDeliveryStatusChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaDeliveryStatusChangeHistoryLog.java
@@ -33,7 +33,7 @@ public class AaDeliveryStatusChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(238 & 0xFF), (byte)(238 >> 8)}, // 238
+            HistoryLog.typeIdBytes(238, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaEnableSettingChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaEnableSettingChangeHistoryLog.java
@@ -45,7 +45,7 @@ public class AaEnableSettingChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int enabled) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(244 & 0xFF), (byte)(244 >> 8)}, // 244
+            HistoryLog.typeIdBytes(244, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) enabled }));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaSleepScheduleChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaSleepScheduleChangeHistoryLog.java
@@ -33,7 +33,7 @@ public class AaSleepScheduleChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(235 & 0xFF), (byte)(235 >> 8)}, // 235
+            HistoryLog.typeIdBytes(235, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaTdiSettingChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaTdiSettingChangeHistoryLog.java
@@ -33,7 +33,7 @@ public class AaTdiSettingChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(245 & 0xFF), (byte)(245 >> 8)}, // 245
+            HistoryLog.typeIdBytes(245, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaWeightSettingChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AaWeightSettingChangeHistoryLog.java
@@ -33,7 +33,7 @@ public class AaWeightSettingChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(246 & 0xFF), (byte)(246 >> 8)}, // 246
+            HistoryLog.typeIdBytes(246, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmAckHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmAckHistoryLog.java
@@ -37,7 +37,7 @@ public class AlarmAckHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alarmId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{8, 0},
+            HistoryLog.typeIdBytes(8, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alarmId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmActivatedHistoryLog.java
@@ -58,7 +58,7 @@ public class AlarmActivatedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alarmId, long faultLocatorData, long param1, float param2) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{5, 0},
+            HistoryLog.typeIdBytes(5, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alarmId),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmClearedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmClearedHistoryLog.java
@@ -40,7 +40,7 @@ public class AlarmClearedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alarmId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{28, 0},
+            HistoryLog.typeIdBytes(28, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alarmId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertAckHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertAckHistoryLog.java
@@ -37,7 +37,7 @@ public class AlertAckHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{27, 0},
+            HistoryLog.typeIdBytes(27, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLog.java
@@ -58,7 +58,7 @@ public class AlertActivatedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId, long faultLocatorData, long param1, float param2) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{4, 0},
+            HistoryLog.typeIdBytes(4, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertClearedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertClearedHistoryLog.java
@@ -43,7 +43,7 @@ public class AlertClearedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId, long faultLocatorData) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{26, 0},
+            HistoryLog.typeIdBytes(26, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ArmInitHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ArmInitHistoryLog.java
@@ -48,7 +48,7 @@ public class ArmInitHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long version, long configABits, long configBBits, long numLogEntries) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{99, 0},
+            HistoryLog.typeIdBytes(99, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(version),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BGHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BGHistoryLog.java
@@ -65,7 +65,7 @@ public class BGHistoryLog extends HistoryLog {
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bg, int cgmCalibration, int bgSource, float iob, int targetBG, int isf, int selectedIOB, int bgSourceType, int spare) {
         return Bytes.combine(
-            new byte[]{ 16, 0 },
+            HistoryLog.typeIdBytes(16, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bg),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLog.java
@@ -54,7 +54,7 @@ public class BasalDeliveryHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{23, 0}, // (byte) 279
+            HistoryLog.typeIdBytes(279, 0), // 279 = 256 + 23 (byte1 must be 1, not 0)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(commandedRateSource),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalIqSettingsChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalIqSettingsChangeHistoryLog.java
@@ -29,7 +29,7 @@ public class BasalIqSettingsChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-114, 0}, // (byte) 142
+            HistoryLog.typeIdBytes(142, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalRateChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalRateChangeHistoryLog.java
@@ -52,7 +52,7 @@ public class BasalRateChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float commandBasalRate, float baseBasalRate, float maxBasalRate, int insulinDeliveryProfile, int changeType) {
         return Bytes.combine(
-            new byte[]{3, 0},
+            HistoryLog.typeIdBytes(3, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(commandBasalRate), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolexActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolexActivatedHistoryLog.java
@@ -48,7 +48,7 @@ public class BolexActivatedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusId, float iob, float bolexSize) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{59, 0},
+            HistoryLog.typeIdBytes(59, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusId), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolexCompletedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolexCompletedHistoryLog.java
@@ -55,7 +55,7 @@ public class BolexCompletedHistoryLog extends HistoryLog {
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested) {
         return Bytes.combine(
-            new byte[]{21, 0},
+            HistoryLog.typeIdBytes(21, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(completionStatus),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLog.java
@@ -68,7 +68,7 @@ public class BolusDeliveryHistoryLog extends HistoryLog {
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatus, int bolusType, int bolusSource, int reserved, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal) {
         return Bytes.combine(
-            new byte[]{24, 1}, // 280 across 2 bytes
+            HistoryLog.typeIdBytes(280, 0), // 280 across 2 bytes
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bolusID), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CannulaFilledHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CannulaFilledHistoryLog.java
@@ -45,7 +45,7 @@ public class CannulaFilledHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float primeSize, long completionStatus) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{61, 0},
+            HistoryLog.typeIdBytes(61, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(primeSize),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CarbEnteredHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CarbEnteredHistoryLog.java
@@ -41,7 +41,7 @@ public class CarbEnteredHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float carbs) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{48, 0},
+            HistoryLog.typeIdBytes(48, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(carbs)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CartridgeFilledHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CartridgeFilledHistoryLog.java
@@ -45,7 +45,7 @@ public class CartridgeFilledHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long insulinDisplay, float insulinActual) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{33, 0},
+            HistoryLog.typeIdBytes(33, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(insulinDisplay), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CartridgeInsertedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CartridgeInsertedHistoryLog.java
@@ -34,7 +34,7 @@ public class CartridgeInsertedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{32, 0},
+            HistoryLog.typeIdBytes(32, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CartridgeRemovedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CartridgeRemovedHistoryLog.java
@@ -34,7 +34,7 @@ public class CartridgeRemovedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{31, 0},
+            HistoryLog.typeIdBytes(31, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckDexHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckDexHistoryLog.java
@@ -53,7 +53,7 @@ public class CgmAlertAckDexHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 371, 0},
+            HistoryLog.typeIdBytes(371, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertAckHistoryLog.java
@@ -53,7 +53,7 @@ public class CgmAlertAckHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 173, 0},
+            HistoryLog.typeIdBytes(173, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedDexHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedDexHistoryLog.java
@@ -53,7 +53,7 @@ public class CgmAlertActivatedDexHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 369, 0},
+            HistoryLog.typeIdBytes(369, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedFsl2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedFsl2HistoryLog.java
@@ -53,7 +53,7 @@ public class CgmAlertActivatedFsl2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 460, 0},
+            HistoryLog.typeIdBytes(460, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertActivatedHistoryLog.java
@@ -62,7 +62,7 @@ public class CgmAlertActivatedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId, long faultLocatorData, long param1, float param2) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 171, 0},
+            HistoryLog.typeIdBytes(171, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedDexHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedDexHistoryLog.java
@@ -53,7 +53,7 @@ public class CgmAlertClearedDexHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 370, 0},
+            HistoryLog.typeIdBytes(370, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedFsl2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedFsl2HistoryLog.java
@@ -53,7 +53,7 @@ public class CgmAlertClearedFsl2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 461, 0},
+            HistoryLog.typeIdBytes(461, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAlertClearedHistoryLog.java
@@ -53,7 +53,7 @@ public class CgmAlertClearedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long alertId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 172, 0},
+            HistoryLog.typeIdBytes(172, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(alertId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAnnuSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmAnnuSettingsHistoryLog.java
@@ -29,7 +29,7 @@ public class CgmAnnuSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 157, 0},
+            HistoryLog.typeIdBytes(157, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmBleCalibrationEvtG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmBleCalibrationEvtG7HistoryLog.java
@@ -37,7 +37,7 @@ public class CgmBleCalibrationEvtG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, boolean isCalibrationAccepted) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(439 & 0xFF), (byte)(439 >> 8)}, // 439 = 0x01B7
+            HistoryLog.typeIdBytes(439, 0), // 439 = 0x01B7
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{(byte)(isCalibrationAccepted ? 1 : 0)}));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationG7HistoryLog.java
@@ -37,7 +37,7 @@ public class CgmCalibrationG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long bg) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(438 & 0xFF), (byte)(438 >> 8)}, // 438 = 0x01B6
+            HistoryLog.typeIdBytes(438, 0), // 438 = 0x01B6
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(bg)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationGxHistoryLog.java
@@ -42,7 +42,7 @@ public class CgmCalibrationGxHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int value) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-46, 0}, // (byte) 210
+            HistoryLog.typeIdBytes(210, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(value)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationHistoryLog.java
@@ -53,7 +53,7 @@ public class CgmCalibrationHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTime, long timestamp, long calTimestamp, int value, int currentDisplayValue) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-96, 0}, // (byte) 160
+            HistoryLog.typeIdBytes(160, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(currentTime), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl2HistoryLog.java
@@ -64,7 +64,7 @@ public class CgmDataFsl2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(372 & 0xFF), (byte)(372 >> 8)}, // 372 = 0x0174
+            HistoryLog.typeIdBytes(372, 0), // 372 = 0x0174
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(status),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl3HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataFsl3HistoryLog.java
@@ -64,7 +64,7 @@ public class CgmDataFsl3HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(480 & 0xFF), (byte)(480 >> 8)}, // 480 = 0x01E0
+            HistoryLog.typeIdBytes(480, 0), // 480 = 0x01E0
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(status),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataGxHistoryLog.java
@@ -60,7 +60,7 @@ public class CgmDataGxHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int status, int type, int rate, int rssi, int value, long timestamp, long transmitterTimestamp) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-45, 0}, // (byte) 211
+            HistoryLog.typeIdBytes(211, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(status), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataSampleHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataSampleHistoryLog.java
@@ -47,7 +47,7 @@ public class CgmDataSampleHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int status, int value) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-105, 0}, // (byte) 151
+            HistoryLog.typeIdBytes(151, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(status),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmFraSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmFraSettingsHistoryLog.java
@@ -56,7 +56,7 @@ public class CgmFraSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int alertLevel, int repeatDuration, boolean isEnabled, int modifiedField) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 168, 0},
+            HistoryLog.typeIdBytes(168, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(alertLevel),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmHgaSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmHgaSettingsHistoryLog.java
@@ -56,7 +56,7 @@ public class CgmHgaSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int alertLevel, int repeatDuration, boolean isEnabled, int modifiedField) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 165, 0},
+            HistoryLog.typeIdBytes(165, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(alertLevel),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmInactiveG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmInactiveG7HistoryLog.java
@@ -29,7 +29,7 @@ public class CgmInactiveG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(441 & 0xFF), (byte)(441 >> 8)}, // 441 = 0x01B9
+            HistoryLog.typeIdBytes(441, 0), // 441 = 0x01B9
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmInactiveGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmInactiveGxHistoryLog.java
@@ -34,7 +34,7 @@ public class CgmInactiveGxHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 215, 0},
+            HistoryLog.typeIdBytes(215, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionFsl2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionFsl2HistoryLog.java
@@ -31,7 +31,7 @@ public class CgmJoinSessionFsl2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 406, 0},
+            HistoryLog.typeIdBytes(406, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionFsl3HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionFsl3HistoryLog.java
@@ -31,7 +31,7 @@ public class CgmJoinSessionFsl3HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 477, 0},
+            HistoryLog.typeIdBytes(477, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionG7HistoryLog.java
@@ -42,7 +42,7 @@ public class CgmJoinSessionG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long cgmTimestamp, long sessionSignature) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 394, 0},
+            HistoryLog.typeIdBytes(394, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(cgmTimestamp),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmJoinSessionHistoryLog.java
@@ -55,7 +55,7 @@ public class CgmJoinSessionHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, int sessionJoinReasonRaw, int sessionDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 213, 0},
+            HistoryLog.typeIdBytes(213, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(currentTransmitterTime),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmLgaSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmLgaSettingsHistoryLog.java
@@ -56,7 +56,7 @@ public class CgmLgaSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int alertLevel, int repeatDuration, boolean isEnabled, int modifiedField) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 166, 0},
+            HistoryLog.typeIdBytes(166, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(alertLevel),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmOorSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmOorSettingsHistoryLog.java
@@ -56,7 +56,7 @@ public class CgmOorSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int alertLevel, int repeatDuration, boolean isEnabled, int modifiedField) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 169, 0},
+            HistoryLog.typeIdBytes(169, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(alertLevel),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmPairingCodeG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmPairingCodeG7HistoryLog.java
@@ -39,7 +39,7 @@ public class CgmPairingCodeG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, String pairingCode) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(395 & 0xFF), (byte)(395 >> 8)},
+            HistoryLog.typeIdBytes(395, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.writeString(pairingCode, 16)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmRejoinSessionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmRejoinSessionHistoryLog.java
@@ -31,7 +31,7 @@ public class CgmRejoinSessionHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(367 & 0xFF), (byte)(367 >> 8)},
+            HistoryLog.typeIdBytes(367, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmRraSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmRraSettingsHistoryLog.java
@@ -56,7 +56,7 @@ public class CgmRraSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int alertLevel, int repeatDuration, boolean isEnabled, int modifiedField) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 167, 0},
+            HistoryLog.typeIdBytes(167, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(alertLevel),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmSensorTypeChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmSensorTypeChangeHistoryLog.java
@@ -31,7 +31,7 @@ public class CgmSensorTypeChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(368 & 0xFF), (byte)(368 >> 8)},
+            HistoryLog.typeIdBytes(368, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmSessionTypeChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmSessionTypeChangeHistoryLog.java
@@ -32,7 +32,7 @@ public class CgmSessionTypeChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{11, 1}, // 267 = 256 + 11
+            HistoryLog.typeIdBytes(267, 0), // 267 = 256 + 11
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSensorReqG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSensorReqG7HistoryLog.java
@@ -31,7 +31,7 @@ public class CgmStartSensorReqG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(390 & 0xFF), (byte)(390 >> 8)},
+            HistoryLog.typeIdBytes(390, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionFsl2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionFsl2HistoryLog.java
@@ -31,7 +31,7 @@ public class CgmStartSessionFsl2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 404, 0},
+            HistoryLog.typeIdBytes(404, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionHistoryLog.java
@@ -52,7 +52,7 @@ public class CgmStartSessionHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, int sessionDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 212, 0},
+            HistoryLog.typeIdBytes(212, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(currentTransmitterTime),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionReqGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStartSessionReqGxHistoryLog.java
@@ -31,7 +31,7 @@ public class CgmStartSessionReqGxHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 217, 0},
+            HistoryLog.typeIdBytes(217, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionFsl2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionFsl2HistoryLog.java
@@ -31,7 +31,7 @@ public class CgmStopSessionFsl2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 405, 0},
+            HistoryLog.typeIdBytes(405, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionFsl3HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionFsl3HistoryLog.java
@@ -31,7 +31,7 @@ public class CgmStopSessionFsl3HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 486, 0},
+            HistoryLog.typeIdBytes(486, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionG7HistoryLog.java
@@ -54,7 +54,7 @@ public class CgmStopSessionG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, long sessionStopTime, int stopSessionCode, int sessionStopReason, int sessionDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(447 & 0xFF), (byte)(447 >> 8)}, // 447 = 0x01BF
+            HistoryLog.typeIdBytes(447, 0), // 447 = 0x01BF
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(currentTransmitterTime),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionHistoryLog.java
@@ -58,7 +58,7 @@ public class CgmStopSessionHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long currentTransmitterTime, long sessionStartTime, long sessionStopTime, int sessionStopReasonRaw, int sessionDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 214, 0},
+            HistoryLog.typeIdBytes(214, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(currentTransmitterTime),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionMsg1HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionMsg1HistoryLog.java
@@ -29,7 +29,7 @@ public class CgmStopSessionMsg1HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 162, 0},
+            HistoryLog.typeIdBytes(162, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionMsg2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionMsg2HistoryLog.java
@@ -29,7 +29,7 @@ public class CgmStopSessionMsg2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 163, 0},
+            HistoryLog.typeIdBytes(163, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionReqG7HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionReqG7HistoryLog.java
@@ -29,7 +29,7 @@ public class CgmStopSessionReqG7HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(443 & 0xFF), (byte)(443 >> 8)}, // 443 = 0x01BB
+            HistoryLog.typeIdBytes(443, 0), // 443 = 0x01BB
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionReqGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmStopSessionReqGxHistoryLog.java
@@ -31,7 +31,7 @@ public class CgmStopSessionReqGxHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 218, 0},
+            HistoryLog.typeIdBytes(218, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmTransmitterIdGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmTransmitterIdGxHistoryLog.java
@@ -31,7 +31,7 @@ public class CgmTransmitterIdGxHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 216, 0},
+            HistoryLog.typeIdBytes(216, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmTransmitterIdHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmTransmitterIdHistoryLog.java
@@ -29,7 +29,7 @@ public class CgmTransmitterIdHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 156, 0},
+            HistoryLog.typeIdBytes(156, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmTransmitterVersionGxHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmTransmitterVersionGxHistoryLog.java
@@ -31,7 +31,7 @@ public class CgmTransmitterVersionGxHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 220, 0},
+            HistoryLog.typeIdBytes(220, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmUnexpectedGeAlertHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmUnexpectedGeAlertHistoryLog.java
@@ -31,7 +31,7 @@ public class CgmUnexpectedGeAlertHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 187, 0},
+            HistoryLog.typeIdBytes(187, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ConfirmCartridgeFilledHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ConfirmCartridgeFilledHistoryLog.java
@@ -34,7 +34,7 @@ public class ConfirmCartridgeFilledHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{41, 0},
+            HistoryLog.typeIdBytes(41, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLog.java
@@ -48,7 +48,7 @@ public class ControlIQPcmChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int currentPcm, int previousPcm) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-26, 0}, // (byte) 230
+            HistoryLog.typeIdBytes(230, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) currentPcm }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQUserModeChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQUserModeChangeHistoryLog.java
@@ -45,7 +45,7 @@ public class ControlIQUserModeChangeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int currentUserMode, int previousUserMode) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-27, 0}, // (byte) 229
+            HistoryLog.typeIdBytes(229, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) currentUserMode }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CorrectionDeclinedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CorrectionDeclinedHistoryLog.java
@@ -53,7 +53,7 @@ public class CorrectionDeclinedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bg, int bolusId, float iob, int targetBg, int isf) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{93, 0},
+            HistoryLog.typeIdBytes(93, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(bg), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyBasalHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyBasalHistoryLog.java
@@ -60,7 +60,7 @@ public class DailyBasalHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float dailyTotalBasal, float lastBasalRate, float iob, boolean finalEventForDay, int actualBatteryCharge, int lipoMv) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{81, 0},
+            HistoryLog.typeIdBytes(81, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(dailyTotalBasal), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DataLogCorruptionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DataLogCorruptionHistoryLog.java
@@ -45,7 +45,7 @@ public class DataLogCorruptionHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long block, int reason) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{60, 0},
+            HistoryLog.typeIdBytes(60, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(block),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DateChangeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DateChangeHistoryLog.java
@@ -49,7 +49,7 @@ public class DateChangeHistoryLog extends HistoryLog {
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long datePrior, long dateAfter, long rawRTCTime) {
         return Bytes.combine(
-            new byte[]{14, 0},
+            HistoryLog.typeIdBytes(14, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(datePrior), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DexcomG6CGMHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DexcomG6CGMHistoryLog.java
@@ -67,7 +67,7 @@ public class DexcomG6CGMHistoryLog extends HistoryLog {
     
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int glucoseValueStatus, int cgmDataType, int rate, int algorithmState, int rssi, int currentGlucoseDisplayValue, long timeStampSeconds, int egvInfoBitmask, int interval) {
         return Bytes.combine(
-            new byte[]{0, 1},
+            HistoryLog.typeIdBytes(256, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(glucoseValueStatus), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DexcomG7CGMHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DexcomG7CGMHistoryLog.java
@@ -66,7 +66,7 @@ public class DexcomG7CGMHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int glucoseValueStatusRaw, int cgmDataTypeRaw, int rate, int algorithmStateRaw, int rssi, int currentGlucoseDisplayValue, int egvTimestamp, int egvInfoBitmask, int interval) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{ (byte) 399, 0x11 },
+            HistoryLog.typeIdBytes(399, 1), // nibble is capture-dependent (see getHeaderHighNibble javadoc); 1 preserved here since all known 399 fixtures carry it
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(glucoseValueStatusRaw), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/FactoryResetHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/FactoryResetHistoryLog.java
@@ -33,7 +33,7 @@ public class FactoryResetHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{82, 0},
+            HistoryLog.typeIdBytes(82, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/FillEstimateFinalHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/FillEstimateFinalHistoryLog.java
@@ -29,7 +29,7 @@ public class FillEstimateFinalHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{98, 0},
+            HistoryLog.typeIdBytes(98, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HypoMinimizerResumeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HypoMinimizerResumeHistoryLog.java
@@ -42,7 +42,7 @@ public class HypoMinimizerResumeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long reason) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-57, 0}, // (byte) 199
+            HistoryLog.typeIdBytes(199, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(reason)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HypoMinimizerSuspendHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HypoMinimizerSuspendHistoryLog.java
@@ -34,7 +34,7 @@ public class HypoMinimizerSuspendHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{-58, 0}, // (byte) 198
+            HistoryLog.typeIdBytes(198, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionHistoryLog.java
@@ -51,7 +51,7 @@ public class IdpActionHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int idp, int status, int sourceIdp, String name) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{69, 0},
+            HistoryLog.typeIdBytes(69, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) idp }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionMsg2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionMsg2HistoryLog.java
@@ -43,7 +43,7 @@ public class IdpActionMsg2HistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int idp, String name) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{57, 0},
+            HistoryLog.typeIdBytes(57, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) idp }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpBolusHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpBolusHistoryLog.java
@@ -55,7 +55,7 @@ public class IdpBolusHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int idp, int modification, int bolusStatus, int insulinDuration, int maxBolusSize, int bolusEntryType) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{70, 0},
+            HistoryLog.typeIdBytes(70, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) idp }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpListHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpListHistoryLog.java
@@ -60,7 +60,7 @@ public class IdpListHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int numProfiles, int slot1, int slot2, int slot3, int slot4, int slot5, int slot6) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{71, 0},
+            HistoryLog.typeIdBytes(71, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) numProfiles },

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpTimeDependentSegmentHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpTimeDependentSegmentHistoryLog.java
@@ -66,7 +66,7 @@ public class IdpTimeDependentSegmentHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int idp, int status, int segmentIndex, int modificationType, int startTime, int basalRate, int isf, long targetBg, int carbRatio) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{68, 0},
+            HistoryLog.typeIdBytes(68, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) idp }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/LogErasedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/LogErasedHistoryLog.java
@@ -42,7 +42,7 @@ public class LogErasedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long numErased) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{0, 0},
+            HistoryLog.typeIdBytes(0, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(numErased)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/MalfunctionAckHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/MalfunctionAckHistoryLog.java
@@ -37,7 +37,7 @@ public class MalfunctionAckHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long malfId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{7, 0},
+            HistoryLog.typeIdBytes(7, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(malfId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/MalfunctionHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/MalfunctionHistoryLog.java
@@ -48,7 +48,7 @@ public class MalfunctionHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long malfId, long faultLocatorData, long param1, float param2) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{6, 0},
+            HistoryLog.typeIdBytes(6, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(malfId),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/NewDayHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/NewDayHistoryLog.java
@@ -48,7 +48,7 @@ public class NewDayHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float commandedBasalRate, long featuresBitmask, long featureBitmaskIndex) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{90, 0},
+            HistoryLog.typeIdBytes(90, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(commandedBasalRate),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeGlobalSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeGlobalSettingsHistoryLog.java
@@ -70,7 +70,7 @@ public class ParamChangeGlobalSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int modifiedData, int qbDataStatus, int qbActive, int qbDataEntryType, int qbIncrementUnits, int qbIncrementCarbs, int buttonVolume, int qbVolume, int bolusVolume, int reminderVolume, int alertVolume) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{74, 0},
+            HistoryLog.typeIdBytes(74, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) modifiedData }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangePumpSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangePumpSettingsHistoryLog.java
@@ -61,7 +61,7 @@ public class ParamChangePumpSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int modification, int status, int lowInsulinThreshold, int cannulaPrimeSize, int isFeatureLocked, int autoShutdownEnabled, int oledTimeout, int autoShutdownDuration) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{73, 0},
+            HistoryLog.typeIdBytes(73, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) modification }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeRemSettingsHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeRemSettingsHistoryLog.java
@@ -53,7 +53,7 @@ public class ParamChangeRemSettingsHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int modification, int status, int lowBgThreshold, int highBgThreshold, int siteChangeDays) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{97, 0},
+            HistoryLog.typeIdBytes(97, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) modification },

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeReminderHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeReminderHistoryLog.java
@@ -63,7 +63,7 @@ public class ParamChangeReminderHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int modification, int reminderId, int status, int enable, long frequencyMinutes, int startTime, int endTime, int activeDays) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{96, 0},
+            HistoryLog.typeIdBytes(96, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) modification }, 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PlgsPeriodicHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PlgsPeriodicHistoryLog.java
@@ -31,7 +31,7 @@ public class PlgsPeriodicHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 140, 0},
+            HistoryLog.typeIdBytes(140, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PrimeInprocessHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PrimeInprocessHistoryLog.java
@@ -31,7 +31,7 @@ public class PrimeInprocessHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(348 & 0xFF), (byte)(348 >> 8)},
+            HistoryLog.typeIdBytes(348, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLog.java
@@ -45,7 +45,7 @@ public class PumpingResumedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long preResumeState, int insulinAmount) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{12, 0},
+            HistoryLog.typeIdBytes(12, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(preResumeState),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLog.java
@@ -49,7 +49,7 @@ public class PumpingSuspendedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long preSuspendState, int insulinAmount, int reason, int rpaTimeout) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{11, 0},
+            HistoryLog.typeIdBytes(11, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(preSuspendState),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ReminderActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ReminderActivatedHistoryLog.java
@@ -37,7 +37,7 @@ public class ReminderActivatedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long reminderId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{25, 0},
+            HistoryLog.typeIdBytes(25, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(reminderId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ReminderDismissedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ReminderDismissedHistoryLog.java
@@ -37,7 +37,7 @@ public class ReminderDismissedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long reminderId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{29, 0},
+            HistoryLog.typeIdBytes(29, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(reminderId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ReminderSnoozedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ReminderSnoozedHistoryLog.java
@@ -37,7 +37,7 @@ public class ReminderSnoozedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long reminderId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{30, 0},
+            HistoryLog.typeIdBytes(30, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(reminderId)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ShelfModeHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ShelfModeHistoryLog.java
@@ -54,7 +54,7 @@ public class ShelfModeHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long msecSinceReset, int lipoIbc, int lipoAbc, int lipoCurrent, long lipoRemCap, long lipoMv) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{53, 0},
+            HistoryLog.typeIdBytes(53, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(msecSinceReset),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/SnoozeActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/SnoozeActivatedHistoryLog.java
@@ -32,7 +32,7 @@ public class SnoozeActivatedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{30, 1}, // 286 = 256 + 30
+            HistoryLog.typeIdBytes(286, 0), // 286 = 256 + 30
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateActivatedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateActivatedHistoryLog.java
@@ -48,7 +48,7 @@ public class TempRateActivatedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float percent, float duration, int tempRateId) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{2, 0},
+            HistoryLog.typeIdBytes(2, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(percent), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateCompletedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateCompletedHistoryLog.java
@@ -45,7 +45,7 @@ public class TempRateCompletedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int tempRateId, long timeLeft) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{15, 0},
+            HistoryLog.typeIdBytes(15, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(tempRateId), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TimeChangedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TimeChangedHistoryLog.java
@@ -48,7 +48,7 @@ public class TimeChangedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long timePrior, long timeAfter, long rawRTC) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{13, 0},
+            HistoryLog.typeIdBytes(13, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(timePrior), 

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TipsErrorHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TipsErrorHistoryLog.java
@@ -46,7 +46,7 @@ public class TipsErrorHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int messageType, int requestCode, int errorCode, boolean isDataMasked) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte)(419 & 0xFF), (byte)(419 >> 8)}, // 419 = 0x01A3
+            HistoryLog.typeIdBytes(419, 0), // 419 = 0x01A3
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{(byte) messageType},

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TipscReqPrimeCannulaHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TipscReqPrimeCannulaHistoryLog.java
@@ -34,7 +34,7 @@ public class TipscReqPrimeCannulaHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{35, 1}, // typeId=291 (256+35)
+            HistoryLog.typeIdBytes(291, 0), // typeId=291 (256+35)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TubingFilledHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TubingFilledHistoryLog.java
@@ -48,7 +48,7 @@ public class TubingFilledHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float primeSize, long completionStatus, long position) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{63, 0},
+            HistoryLog.typeIdBytes(63, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(primeSize),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UpdateStatusHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UpdateStatusHistoryLog.java
@@ -57,7 +57,7 @@ public class UpdateStatusHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int swUpdateStatus, int metadataAndVersionStatus, int fullDlAndCrcStatus, int fileDlAndSideloadStatus, int externalFlashStatus, int updateSuccessful, long swPartNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 203, 0},
+            HistoryLog.typeIdBytes(203, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(metadataAndVersionStatus),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbConnectedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbConnectedHistoryLog.java
@@ -41,7 +41,7 @@ public class UsbConnectedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float negotiatedCurrentmA) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{36, 0},
+            HistoryLog.typeIdBytes(36, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(negotiatedCurrentmA)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbDisconnectedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbDisconnectedHistoryLog.java
@@ -41,7 +41,7 @@ public class UsbDisconnectedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, float negotiatedCurrentMilliAmps) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{37, 0},
+            HistoryLog.typeIdBytes(37, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toFloat(negotiatedCurrentMilliAmps)));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbEnumeratedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbEnumeratedHistoryLog.java
@@ -41,7 +41,7 @@ public class UsbEnumeratedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int negotiatedCurrentMilliAmps) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{67, 0},
+            HistoryLog.typeIdBytes(67, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             new byte[]{ (byte) negotiatedCurrentMilliAmps }));

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/VersionInfoHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/VersionInfoHistoryLog.java
@@ -48,7 +48,7 @@ public class VersionInfoHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, long version, long configABits, long configBBits, int armCrc) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{(byte) 191, 0},
+            HistoryLog.typeIdBytes(191, 0),
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.toUint32(version),

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/WumpCartridgeFilledHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/WumpCartridgeFilledHistoryLog.java
@@ -34,7 +34,7 @@ public class WumpCartridgeFilledHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{45, 1}, // typeId=301 (256+45)
+            HistoryLog.typeIdBytes(301, 0), // typeId=301 (256+45)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/WumpCartridgeRemovedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/WumpCartridgeRemovedHistoryLog.java
@@ -34,7 +34,7 @@ public class WumpCartridgeRemovedHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{46, 1}, // typeId=302 (256+46)
+            HistoryLog.typeIdBytes(302, 0), // typeId=302 (256+46)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/WumpOcclusionDebugHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/WumpOcclusionDebugHistoryLog.java
@@ -32,7 +32,7 @@ public class WumpOcclusionDebugHistoryLog extends HistoryLog {
 
     public static byte[] buildCargo(long pumpTimeSec, long sequenceNum) {
         return HistoryLog.fillCargo(Bytes.combine(
-            new byte[]{27, 1}, // 283 = 256 + 27
+            HistoryLog.typeIdBytes(283, 0), // 283 = 256 + 27
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum)));
     }


### PR DESCRIPTION
`HistoryLog.typeIdBytes(int typeId, int headerHighNibble)` already correctly encodes the two-byte little-endian header (low 12 bits typeId, top 4 bits header nibble), but no class called it. Every `buildCargo` in `messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/` hand-rolled the two header bytes using one of three inconsistent patterns. This PR replaces all of them with `HistoryLog.typeIdBytes(...)`.

The pattern `new byte[]{(byte) NNN, 0}` silently truncates opcodes above 255 (e.g. `(byte) 369` = 0x71, with the second byte staying `0` instead of `1`), so the serialized record claimed the wrong (truncated) typeId. The following 12 classes had this bug and are now fixed:

- BasalDeliveryHistoryLog (279 — second header byte must be 1, not 0)
- CgmAlertActivatedDexHistoryLog (369)
- CgmAlertClearedDexHistoryLog (370)
- CgmAlertAckDexHistoryLog (371)
- CgmJoinSessionG7HistoryLog (394)
- CgmStartSessionFsl2HistoryLog (404)
- CgmStopSessionFsl2HistoryLog (405)
- CgmJoinSessionFsl2HistoryLog (406)
- CgmAlertActivatedFsl2HistoryLog (460)
- CgmAlertClearedFsl2HistoryLog (461)
- CgmJoinSessionFsl3HistoryLog (477)
- CgmStopSessionFsl3HistoryLog (486)

The remaining ~113 migrated classes (typeIds <= 255, or already using the correct `(byte)(N & 0xFF), (byte)(N >> 8)` shift form) are byte-identical — only the source construction changed, not the serialized output.

One deliberate exception: `DexcomG7CGMHistoryLog` (399) previously hard-coded `{(byte) 399, 0x11}`. This is now `HistoryLog.typeIdBytes(399, 1)`, which reproduces the exact same bytes — the header nibble is capture-dependent (see `getHeaderHighNibble` javadoc), and `1` is preserved here because all known 399 fixtures carry it.

`DailyStatusHistoryLog` (313) and `VersionsAHistoryLog` (307) already called `HistoryLog.typeIdBytes(...)` and needed no changes; `HistoryLogStreamResponse` was left untouched since its leading bytes are `numberOfHistoryLogs`/`streamId`, not a per-record typeId header.

No test assertions needed to change — `./gradlew :messages:test` was green both before and after (nothing was asserting the previously-truncated header bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_