### PR TITLE
Name known alert ids in place of placeholders

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/CGMAlertStatusResponse.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/CGMAlertStatusResponse.java
@@ -119,10 +119,11 @@ public class CGMAlertStatusResponse extends NotificationMessage {
         DEFAULT_CGM_ALERT_42(42),
         DEFAULT_CGM_ALERT_43(43),
         DEFAULT_CGM_ALERT_44(44),
-        DEFAULT_CGM_ALERT_45(45),
-        DEFAULT_CGM_ALERT_46(46),
+        // Names derived from tconnectsync's cloud-export dictionaries (CGM_ALERTS_DICT).
+        TRANSMITTER_EXPIRING_CGM_ALERT(45), // CGM_ALERTS_DICT["45"] == "CGM Transmitter Expiring Soon"
+        TRANSMITTER_EXPIRING_CGM_ALERT2(46), // CGM_ALERTS_DICT["46"] == "CGM Transmitter Expiring 2"
         DEFAULT_CGM_ALERT_47(47),
-        DEFAULT_CGM_ALERT_48(48),
+        UNAVAILABLE_CGM_ALERT(48), // CGM_ALERTS_DICT["48"] == "CGM Unavailable"
         DEFAULT_CGM_ALERT_49(49),
         DEFAULT_CGM_ALERT_50(50),
         DEFAULT_CGM_ALERT_51(51),


### PR DESCRIPTION
Renames the `CGMAlertStatusResponse.CGMAlert` placeholder ids that now have known names, confirmed from tconnectsync's cloud-export dictionaries.

| Enum | id | old | new | name source |
| --- | --- | --- | --- | --- |
| `CGMAlertStatusResponse.CGMAlert` | 45 | `DEFAULT_CGM_ALERT_45` | `TRANSMITTER_EXPIRING_CGM_ALERT` | tconnectsync `CGM_ALERTS_DICT["45"]` == "CGM Transmitter Expiring Soon" |
| `CGMAlertStatusResponse.CGMAlert` | 46 | `DEFAULT_CGM_ALERT_46` | `TRANSMITTER_EXPIRING_CGM_ALERT2` | tconnectsync `CGM_ALERTS_DICT["46"]` == "CGM Transmitter Expiring 2" |
| `CGMAlertStatusResponse.CGMAlert` | 48 | `DEFAULT_CGM_ALERT_48` | `UNAVAILABLE_CGM_ALERT` | tconnectsync `CGM_ALERTS_DICT["48"]` == "CGM Unavailable" |

New names follow the enum's existing convention (constants suffixed `_CGM_ALERT`, with a trailing digit for the second occurrence of a name, e.g. `SENSOR_EXPIRING_CGM_ALERT`/`SENSOR_EXPIRING_CGM_ALERT2`).

`AlertStatusResponse.AlertResponseType.CONTROL_IQ_LOW(51, ...)` was already named correctly in this repo — only the Swift mirror in TandemKit needed updating there (companion PR: jwoglom/TandemKit#304).

Grepped the whole repo for the old constant names; `CGMAlertStatusResponse.java` was the only file referencing them.

`JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :messages:test` passes (`BUILD SUCCESSFUL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm

---
_Generated by [Claude Code](https://claude.ai/code/session_01P93H2Avp5zLLg61TzR1ocm)_