### PR TITLE
ci: run the messages test suite on pull requests

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -30,7 +30,7 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           TOKEN: ${{ secrets.TOKEN }}
         run: |
-          ./gradlew :sampleapp:assembleRelease publishToMavenLocal testDebugUnitTest \
+          ./gradlew :sampleapp:assembleRelease publishToMavenLocal testDebugUnitTest :messages:test \
             publishAllPublicationsToGitHubPackagesRepository -PbuildRelease
 
       - name: Android Test Report

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,7 +38,13 @@ jobs:
       # tests reusing the already-compiled outputs. Drops `gradle build` which
       # also runs lintAnalyzeDebug, lintVitalAnalyzeRelease, and
       # testReleaseUnitTest — none of which CI ships.
-      run: ./gradlew :sampleapp:assembleDebug :sampleapp:assembleRelease publishToMavenLocal testDebugUnitTest
+      #
+      # :messages:test is named explicitly because testDebugUnitTest only exists
+      # on the Android modules; messages is a plain Java library whose tests live
+      # on the `test` task, so without this its suite never runs. A bare `test`
+      # would work but also pulls in testReleaseUnitTest on the Android modules,
+      # which is exactly what the comment above says this invocation drops.
+      run: ./gradlew :sampleapp:assembleDebug :sampleapp:assembleRelease publishToMavenLocal testDebugUnitTest :messages:test
 
     - name: Upload debug APK
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Salvaged from #102, rebased onto `dev` and split so it stands alone.

## The problem

`testDebugUnitTest` only exists on the Android modules (`androidLib`, `sampleapp`). `messages` is a plain Java library whose tests live on the `test` task, so CI has been running the 8 `androidLib` tests and **none of the 673 in `messages`**. A change touching only the protocol library can go green without executing a single one of its own tests.

`code-coverage.yml` would have caught this via `gradle build`, but its `push` and `pull_request` triggers are commented out, leaving it `workflow_dispatch` only.

## The change

Adds `:messages:test` to the Gradle invocation in `android.yml` and `android-release.yml`.

Named explicitly rather than using a bare `test`, because on the Android modules `test` also pulls in `testReleaseUnitTest` — exactly what the existing comment says the invocation deliberately drops.

`code-coverage.yml` is left alone. It runs on macOS and drives an emulator for `connectedCheck`, so turning its triggers back on is a separate cost/benefit call.

## Testing

`./gradlew :messages:test` against `dev` is green — **673 tests, 0 failures, 33 skipped**. Enabling this does not turn CI red.

---
_Generated by [Claude Code](https://claude.ai/code/session_019P29DrgdD6rrdZ7N7Vtv5k)_