### PR TITLE
fix: correct UTF-8 and fixed-width handling in Bytes string helpers

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/helpers/Bytes.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/helpers/Bytes.java
@@ -15,19 +15,15 @@ public class Bytes {
     public static int UByteMaxValue = 255; // taken from kotlin
 
     public static byte[] dropFirstN(byte[] bytes, int n) {
-        byte[] ret = new byte[bytes.length - n];
-        for (int i=0; i < bytes.length - n; i++) {
-            ret[i] = bytes[i+n];
-        }
-        return ret;
+        Validate.isTrue(n >= 0 && n <= bytes.length,
+                "cannot drop first %d of %d bytes", n, bytes.length);
+        return Arrays.copyOfRange(bytes, n, bytes.length);
     }
 
     public static byte[] dropLastN(byte[] bytes, int n) {
-        byte[] ret = new byte[bytes.length - n];
-        for (int i=0; i < bytes.length - n; i++) {
-            ret[i] = bytes[i];
-        }
-        return ret;
+        Validate.isTrue(n >= 0 && n <= bytes.length,
+                "cannot drop last %d of %d bytes", n, bytes.length);
+        return Arrays.copyOfRange(bytes, 0, bytes.length - n);
     }
 
     public static byte[] reverse(byte[] bytes) {
@@ -135,30 +131,46 @@ public class Bytes {
         return Arrays.copyOfRange(bytes, 0, 1);
     }
 
+    /**
+     * Reads a NUL-terminated, fixed-width UTF-8 string of at most {@code length} bytes
+     * starting at offset {@code i}.
+     *
+     * <p>Terminates on the NUL byte only. It previously terminated on any byte whose signed
+     * value was {@code <= 0}, which includes every continuation and lead byte of a multi-byte
+     * UTF-8 sequence, so a field holding non-ASCII text (an IDP profile name, for instance) was
+     * cut off at its first byte {@code >= 0x80} rather than decoded.
+     */
     public static String readString(byte[] raw, int i, int length) {
-        if (i >= 0 && i < raw.length) {
-            byte[] strBytes = new byte[0];
-            byte b;
-            while (i < raw.length && (b = raw[i]) > 0) {
-                strBytes = combine(strBytes, new byte[]{b});
-                if (strBytes.length >= length) {
-                    break;
-                }
-                i++;
-            }
-            return new String(strBytes, StandardCharsets.UTF_8);
+        if (i < 0 || i >= raw.length) {
+            throw new ArrayIndexOutOfBoundsException(i);
         }
-        throw new ArrayIndexOutOfBoundsException(i);
+        Validate.isTrue(length >= 0, "length must be non-negative, got %d", length);
+
+        int end = Math.min(raw.length, i + length);
+        int terminator = i;
+        while (terminator < end && raw[terminator] != 0) {
+            terminator++;
+        }
+        return new String(raw, i, terminator - i, StandardCharsets.UTF_8);
     }
 
-    // null byte pads the string to the given length
+    /**
+     * Encodes {@code input} as UTF-8 into a fixed-width field of exactly {@code length} bytes,
+     * NUL-padded on the right.
+     *
+     * <p>Rejects input that does not fit. It previously returned the encoded bytes unpadded when
+     * they were longer than {@code length}, so the caller built cargo of the wrong size and sent
+     * it to the pump. Note the bound is on encoded <em>bytes</em>, not characters: callers passing
+     * user-supplied text (IDP profile names) should validate ahead of this rather than relying on
+     * the exception.
+     */
     public static byte[] writeString(String input, int length) {
+        Validate.isTrue(length >= 0, "length must be non-negative, got %d", length);
         byte[] encoded = input.getBytes(StandardCharsets.UTF_8);
-        for (int i=encoded.length; i < length; i++) {
-            encoded = combine(encoded, new byte[]{0});
-        }
+        Validate.isTrue(encoded.length <= length,
+                "string encodes to %d bytes which does not fit a %d byte field", encoded.length, length);
 
-        return encoded;
+        return Arrays.copyOf(encoded, length);
     }
 
     private static final int[] crcLookupTable = {0, 4129, 8258, 12387, 16516, 20645, 24774, 28903, 33032, 37161, 41290, 45419, 49548, 53677, 57806, 61935, 4657, 528, 12915, 8786, 21173, 17044, 29431, 25302, 37689, 33560, 45947, 41818, 54205, 50076, 62463, 58334, 9314, 13379, 1056, 5121, 25830, 29895, 17572, 21637, 42346, 46411, 34088, 38153, 58862, 62927, 50604, 54669, 13907, 9842, 5649, 1584, 30423, 26358, 22165, 18100, 46939, 42874, 38681, 34616, 63455, 59390, 55197, 51132, 18628, 22757, 26758, 30887, 2112, 6241, 10242, 14371, 51660, 55789, 59790, 63919, 35144, 39273, 43274, 47403, 23285, 19156, 31415, 27286, 6769, 2640, 14899, 10770, 56317, 52188, 64447, 60318, 39801, 35672, 47931, 43802, 27814, 31879, 19684, 23749, 11298, 15363, 3168, 7233, 60846, 64911, 52716, 56781, 44330, 48395, 36200, 40265, 32407, 28342, 24277, 20212, 15891, 11826, 7761, 3696, 65439, 61374, 57309, 53244, 48923, 44858, 40793, 36728, 37256, 33193, 45514, 41451, 53516, 49453, 61774, 57711, 4224, 161, 12482, 8419, 20484, 16421, 28742, 24679, 33721, 37784, 41979, 46042, 49981, 54044, 58239, 62302, 689, 4752, 8947, 13010, 16949, 21012, 25207, 29270, 46570, 42443, 38312, 34185, 62830, 58703, 54572, 50445, 13538, 9411, 5280, 1153, 29798, 25671, 21540, 17413, 42971, 47098, 34713, 38840, 59231, 63358, 50973, 55100, 9939, 14066, 1681, 5808, 26199, 30326, 17941, 22068, 55628, 51565, 63758, 59695, 39368, 35305, 47498, 43435, 22596, 18533, 30726, 26663, 6336, 2273, 14466, 10403, 52093, 56156, 60223, 64286, 35833, 39896, 43963, 48026, 19061, 23124, 27191, 31254, 2801, 6864, 10931, 14994, 64814, 60687, 56684, 52557, 48554, 44427, 40424, 36297, 31782, 27655, 23652, 19525, 15522, 11395, 7392, 3265, 61215, 65342, 53085, 57212, 44955, 49082, 36825, 40952, 28183, 32310, 20053, 24180, 11923, 16050, 3793, 7920};

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/helpers/BytesTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/helpers/BytesTest.java
@@ -1,8 +1,11 @@
 package com.jwoglom.pumpx2.pump.messages.helpers;
 
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -34,5 +37,78 @@ public class BytesTest {
             byte[] back = Bytes.toFloat(read);
             assertHexEquals(bytes, back);
         });
+    }
+
+    @Test
+    public void testDropFirstN() {
+        byte[] input = new byte[]{1, 2, 3, 4};
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, Bytes.dropFirstN(input, 0));
+        assertArrayEquals(new byte[]{3, 4}, Bytes.dropFirstN(input, 2));
+        assertArrayEquals(new byte[]{}, Bytes.dropFirstN(input, 4));
+
+        assertThrows(IllegalArgumentException.class, () -> Bytes.dropFirstN(input, -1));
+        assertThrows(IllegalArgumentException.class, () -> Bytes.dropFirstN(input, 5));
+    }
+
+    @Test
+    public void testDropLastN() {
+        byte[] input = new byte[]{1, 2, 3, 4};
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, Bytes.dropLastN(input, 0));
+        assertArrayEquals(new byte[]{1, 2}, Bytes.dropLastN(input, 2));
+        assertArrayEquals(new byte[]{}, Bytes.dropLastN(input, 4));
+
+        assertThrows(IllegalArgumentException.class, () -> Bytes.dropLastN(input, -1));
+        assertThrows(IllegalArgumentException.class, () -> Bytes.dropLastN(input, 5));
+    }
+
+    @Test
+    public void testReadStringStopsAtNulAndFieldWidth() {
+        byte[] raw = "abc\0defgh".getBytes(StandardCharsets.UTF_8);
+
+        assertEquals("abc", Bytes.readString(raw, 0, 8));
+        // the field width bounds the read even with no terminator inside it
+        assertEquals("ab", Bytes.readString(raw, 0, 2));
+        assertEquals("def", Bytes.readString(raw, 4, 3));
+        // an empty field is a leading NUL, not an error
+        assertEquals("", Bytes.readString(raw, 3, 4));
+        // reads are clamped to the array, not just the field width
+        assertEquals("defgh", Bytes.readString(raw, 4, 100));
+    }
+
+    @Test
+    public void testReadStringDecodesNonAscii() {
+        // Every byte of a multi-byte UTF-8 sequence is negative as a signed byte, so the
+        // previous `raw[i] > 0` terminator cut these fields off at the first non-ASCII byte.
+        for (String s : List.of("café", "Ünïcøde", "日本語", "aéb")) {
+            byte[] field = Bytes.writeString(s, 32);
+            assertEquals(s, Bytes.readString(field, 0, 32));
+        }
+    }
+
+    @Test
+    public void testWriteStringPadsToExactWidth() {
+        assertArrayEquals(new byte[]{'a', 'b', 'c', 0, 0}, Bytes.writeString("abc", 5));
+        assertArrayEquals(new byte[]{'a', 'b', 'c'}, Bytes.writeString("abc", 3));
+        assertArrayEquals(new byte[]{0, 0}, Bytes.writeString("", 2));
+
+        // The field width counts encoded bytes, not characters: "é" is two bytes.
+        assertEquals(4, Bytes.writeString("é", 4).length);
+        assertArrayEquals(new byte[]{(byte) 0xc3, (byte) 0xa9, 0, 0}, Bytes.writeString("é", 4));
+    }
+
+    @Test
+    public void testWriteStringRejectsOverlongInput() {
+        // Previously returned a 4-byte array for a 3-byte field, producing cargo of the
+        // wrong size that would then be sent to the pump.
+        assertThrows(IllegalArgumentException.class, () -> Bytes.writeString("abcd", 3));
+        // Fits as characters but not as encoded bytes.
+        assertThrows(IllegalArgumentException.class, () -> Bytes.writeString("é", 1));
+    }
+
+    @Test
+    public void testWriteStringReadStringRoundTrip() {
+        for (String s : List.of("", "a", "abcdefgh", "café")) {
+            assertEquals(s, Bytes.readString(Bytes.writeString(s, 16), 0, 16));
+        }
     }
 }


### PR DESCRIPTION
Salvaged from #102, rebased onto `dev` and split so it stands alone.

## `readString` mangled non-ASCII fields

It terminated on any byte whose **signed** value was `<= 0`. Every lead and continuation byte of a multi-byte UTF-8 sequence is negative as a signed byte, so a field holding non-ASCII text was cut off at its first byte `>= 0x80` rather than decoded — `"café"` read back as `"caf"`.

It now terminates on the NUL byte and bounds the read by the field width, which is what the callers' fixed-width layouts already assume.

## `writeString` could return the wrong number of bytes

When the encoded string was longer than the field, it returned the encoded bytes unpadded — so the caller built cargo of the wrong size and sent it to the pump. It now always returns exactly `length` bytes and rejects input that does not fit.

The bound is on encoded **bytes**, not characters. Callers passing user-supplied text (IDP profile names via `CreateIDPRequest` and `RenameIDPRequest`) should validate ahead of this rather than relying on the exception.

## `dropFirstN` / `dropLastN` had no bounds check

They allocated `new byte[bytes.length - n]`, throwing `NegativeArraySizeException` for an oversized or negative `n`. They now validate and use `Arrays.copyOfRange`. `readString` also drops its quadratic `combine()` loop for the same reason.

## Testing

`BytesTest` gains coverage for the round trips, the non-ASCII decode, the exact-width guarantee and the rejected overlong write.

- `./gradlew :messages:test` — **680 tests, 0 failures** (673 before these 7)
- `./gradlew :androidLib:compileDebugJavaWithJavac :androidLib:testDebugUnitTest` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_019P29DrgdD6rrdZ7N7Vtv5k)_