### PR TITLE
fix: make the finishRequestMessage null guard actually fire

### DIFF
--- a/androidLib/src/main/java/com/jwoglom/pumpx2/pump/PumpState.java
+++ b/androidLib/src/main/java/com/jwoglom/pumpx2/pump/PumpState.java
@@ -227,7 +227,10 @@ public class PumpState {
         synchronized (requestMessages) {
             Pair<Characteristic, Byte> key = Pair.create(c, txId);
             Pair<Boolean, Message> pair = requestMessages.get(key);
-            Validate.notNull(pair != null, "could not find requestMessage for txId " + txId + " and char " + c);
+            // Validate.notNull takes an Object, so `pair != null` autoboxed to a Boolean that is
+            // never itself null: the guard never fired, and a missing request message surfaced as
+            // a bare NullPointerException on the next line instead of this message.
+            Validate.notNull(pair, "could not find requestMessage for txId " + txId + " and char " + c);
             if (pair.first) {
                 Timber.w("txId " + txId + " was already processed for char " + c + ": pair=" + pair + " requestMessages=" + requestMessages);
             }

--- a/androidLib/src/main/java/com/jwoglom/pumpx2/pump/PumpState.java
+++ b/androidLib/src/main/java/com/jwoglom/pumpx2/pump/PumpState.java
@@ -227,9 +227,6 @@ public class PumpState {
         synchronized (requestMessages) {
             Pair<Characteristic, Byte> key = Pair.create(c, txId);
             Pair<Boolean, Message> pair = requestMessages.get(key);
-            // Validate.notNull takes an Object, so `pair != null` autoboxed to a Boolean that is
-            // never itself null: the guard never fired, and a missing request message surfaced as
-            // a bare NullPointerException on the next line instead of this message.
             Validate.notNull(pair, "could not find requestMessage for txId " + txId + " and char " + c);
             if (pair.first) {
                 Timber.w("txId " + txId + " was already processed for char " + c + ": pair=" + pair + " requestMessages=" + requestMessages);


### PR DESCRIPTION
Salvaged from #102, rebased onto `dev` and split so it stands alone.

`PumpState.finishRequestMessage` called `Validate.notNull(pair != null, ...)`. `Validate.notNull` takes an `Object`, so the comparison autoboxed to a `Boolean` — which is never itself null — and the check passed regardless of whether the request message was found. A missing entry then surfaced one line later as a bare `NullPointerException` on `pair.first`, without the txId and characteristic that the message was there to report.

Passing `pair` itself keeps the same exception type and restores the intended message.

No other call site in the tree has this shape (`grep -rn "Validate.notNull(.*!=\s*null"` returns nothing else).

## Testing

`./gradlew :androidLib:compileDebugJavaWithJavac :androidLib:testDebugUnitTest` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019P29DrgdD6rrdZ7N7Vtv5k)_