### PR TITLE
build: un-nest the androidLib buildTypes block

### DIFF
--- a/androidLib/build.gradle
+++ b/androidLib/build.gradle
@@ -36,11 +36,12 @@ android {
         debug {
             buildConfigField("String", "PUMPX2_VERSION", "\"${rootProject.getVersion()}\"")
             buildConfigField("String", "PUMPX2_BUILD_TIME", "\"${gitCommitTime}\"")
-        }
-        buildTypes {
-            debug {
-                testCoverageEnabled true
-            }
+
+            // Only unit test coverage is enabled: enableAndroidTestCoverage would instrument the
+            // debug library itself, and so the sampleapp debug APK that CI publishes as an
+            // artifact. Only the release variant is published to Maven (see singleVariant below),
+            // so neither flag can reach consumers of the library.
+            enableUnitTestCoverage true
         }
     }
     compileOptions {


### PR DESCRIPTION
Salvaged from #102, rebased onto `dev` and split so it stands alone.

## The problem

`androidLib/build.gradle` had a `buildTypes { debug { testCoverageEnabled true } }` block nested **inside** the outer `buildTypes` block. In the Groovy DSL the inner name registers against the build type container, so this created a third build type literally named `buildTypes` and set the coverage flag on that — leaving the real `debug` build type with coverage off.

The phantom build type is a full variant carrying **77 tasks of its own** (`compileBuildTypesSources`, `testBuildTypesUnitTest`, `lintBuildTypes`, `jacocoTestBuildTypesUnitTestReport`, …), all of which `gradle build` picks up. `code-coverage.yml` runs `gradle build`, so it was compiling and testing an entire extra variant.

## The change

The flag moves onto the real `debug` build type, spelled `enableUnitTestCoverage` since `testCoverageEnabled` is deprecated in AGP 8 and removed in 9.

Only unit test coverage is enabled — `enableAndroidTestCoverage` would instrument the debug library and therefore the sampleapp debug APK that CI uploads as an artifact. Only the `release` variant is published to Maven (`singleVariant("release")`), so neither flag can reach library consumers.

## One thing worth flagging

**The jacoco report is unchanged by the flag.** The mxalbert jacoco-android plugin drives its own `JacocoReport` tasks off the `tasks.withType(Test)` config further down, and `jacocoTestDebugUnitTestReport` records the same 37 covered / 5260 missed instructions before and after. I kept the line because it is what the original block intended, but the defect actually being fixed here is the phantom variant — **dropping the line entirely instead is a reasonable call** if you'd prefer.

## Testing

Verified with a `projectsEvaluated` probe over `android.buildTypes`:

| | build types on androidLib |
|---|---|
| before | `buildTypes` (cov=true), `debug` (cov=false), `release` |
| after | `debug` (cov=true), `release` |

`:androidLib:testDebugUnitTest` and `:androidLib:assembleRelease` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_019P29DrgdD6rrdZ7N7Vtv5k)_