### PR TITLE
security: compare authentication digests in constant time

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/PacketArrayList.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/PacketArrayList.java
@@ -13,6 +13,7 @@ import com.jwoglom.pumpx2.shared.Hex;
 import org.apache.commons.lang3.Validate;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Set;
 
@@ -114,7 +115,9 @@ public class PacketArrayList {
             byte[] bArr2 = this.messageData;
             byte[] expectedHmac = Bytes.dropFirstN(bArr2, bArr2.length - 20);
             byte[] hmacSha = Packetize.doHmacSha1(byteArray, authKey);
-            if (!Arrays.equals(expectedHmac, hmacSha)) {
+            // MessageDigest.isEqual is the constant-time comparison; Arrays.equals returns as
+            // soon as it hits a differing byte.
+            if (!MessageDigest.isEqual(expectedHmac, hmacSha)) {
                 L.e(TAG, "Pump response invalid signature: expectedHmac=" + Hex.encodeHexString(expectedHmac)+" hmacSha="+Hex.encodeHexString(hmacSha));
                 if (shouldIgnoreInvalidHmac(authKey)) {
                     return true;

--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/builders/JpakeAuthBuilder.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/builders/JpakeAuthBuilder.java
@@ -21,6 +21,7 @@ import com.jwoglom.pumpx2.shared.Hex;
 import com.jwoglom.pumpx2.shared.L;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -182,7 +183,9 @@ public class JpakeAuthBuilder {
             step = JpakeStep.CONFIRM_4_SENT;
         } else if (step == JpakeStep.CONFIRM_4_RECEIVED) {
             byte[] hashDigest4 = HmacSha256.hmacSha256(serverNonce4, Hkdf.build(serverNonce3, derivedSecret));
-            if (Hex.encodeHexString(this.serverHashDigest4).equals(Hex.encodeHexString(hashDigest4))) {
+            // MessageDigest.isEqual is the constant-time comparison; the hex round trip it
+            // replaces short-circuited on the first differing nibble.
+            if (MessageDigest.isEqual(this.serverHashDigest4, hashDigest4)) {
                 L.i(TAG, "JpakeAuthBuilder HMAC SECRET VALIDATES");
                 step = JpakeStep.COMPLETE;
             } else {

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/builders/SimulatedJpakeAuthBuilderIntegrationTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/builders/SimulatedJpakeAuthBuilderIntegrationTest.java
@@ -3,6 +3,7 @@ package com.jwoglom.pumpx2.pump.messages.builders;
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -201,5 +202,43 @@ public class SimulatedJpakeAuthBuilderIntegrationTest {
         assertNull(b.nextRequest());
         assertEquals(JpakeAuthBuilder.JpakeStep.COMPLETE, b.step);
         assertTrue(b.done());
+    }
+
+    /**
+     * The same handshake as {@link #testWithDerivedSecret()} up to key confirmation, but the
+     * server's hash digest is corrupted. Covers the rejecting branch of the digest comparison,
+     * which the two passing handshakes above never reach.
+     */
+    @Test
+    public void testKeyConfirmationRejectsWrongServerDigest() throws DecoderException {
+        for (int corruptIndex : new int[]{0, 15, 31}) {
+            SecureRandomMock rand = new SecureRandomMock(Hex.decodeHex(
+                    "e734344901549417" +
+                    "998c182c9d70a375" +
+                    "ad08275f109e41b0"));
+
+            byte[] derivedSecret = Hex.decodeHex("45d66d65aedfd39ce50be0eacca491ff183b7e1c22bf722b8dfb20408e0c78d4");
+            JpakeAuthBuilder b = new JpakeAuthBuilder("passw0rd", derivedSecret, rand);
+
+            b.nextRequest();
+            byte[] nonce = b.generateNonce();
+            b.processResponse(new Jpake3SessionKeyResponse(0, nonce, Jpake3SessionKeyResponse.RESERVED));
+            b.nextRequest();
+
+            byte[] serverNonce = b.generateNonce();
+            byte[] serverHashDigest = HmacSha256.hmacSha256(serverNonce, Hkdf.build(b.serverNonce3, b.derivedSecret));
+
+            // Flip one bit. A first-byte, middle-byte and last-byte corruption must all be
+            // rejected identically -- the comparison must not stop early on a mismatch.
+            byte[] corrupted = Arrays.copyOf(serverHashDigest, serverHashDigest.length);
+            corrupted[corruptIndex] ^= 0x01;
+
+            b.processResponse(new Jpake4KeyConfirmationResponse(
+                    0, serverNonce, Jpake4KeyConfirmationResponse.RESERVED, corrupted));
+
+            assertNull(b.nextRequest());
+            assertEquals("corruptIndex=" + corruptIndex, JpakeAuthBuilder.JpakeStep.INVALID, b.step);
+            assertFalse(b.done());
+        }
     }
 }


### PR DESCRIPTION
Salvaged from #102, rebased onto `dev` and split so it stands alone.

Two secret-dependent equality checks short-circuited on the first differing byte, so how long they took leaked how much of a guessed digest was correct:

- `PacketArrayList.validate` compared the pump's response HMAC with `Arrays.equals`.
- `JpakeAuthBuilder`'s key confirmation hex-encoded both digests and compared the resulting `String`s — the same early exit via `String.equals` over 64 chars, plus two throwaway hex strings of key-confirmation material per handshake.

Both now use `MessageDigest.isEqual`, which is specified to be constant-time with respect to the contents of the arrays. Same accept/reject behaviour either way; this only changes the timing.

## Scope

**Neither is remotely exploitable as it stands.** Both run against a pump over BLE, where connection-interval jitter is orders of magnitude larger than the signal. This is a default worth having on the authentication path, not a live vulnerability — flagging that explicitly since #102 overstated its findings.

Note also that #102 claimed `shouldIgnoreInvalidHmac` throws `ArrayIndexOutOfBoundsException` for keys shorter than its sentinel prefix. That is **not** correct — `Arrays.copyOfRange` zero-pads when `to > length` and only throws when `from > length` — so that part is deliberately not carried over.

## Testing

Adds `testKeyConfirmationRejectsWrongServerDigest`, which drives the handshake to key confirmation with the server digest corrupted at its first, middle and last byte and asserts `JpakeStep.INVALID` for each. The two existing handshake tests only ever reach the accepting branch.

Verified the new test fails if the comparison is stubbed to always accept.

- `./gradlew :messages:test` — **674 tests, 0 failures** (673 before this one)
- `./gradlew :androidLib:compileDebugJavaWithJavac` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_019P29DrgdD6rrdZ7N7Vtv5k)_