### PR TITLE
fix: give saved packet accumulators a lifecycle

### DIFF
--- a/androidLib/src/main/java/com/jwoglom/pumpx2/pump/PumpState.java
+++ b/androidLib/src/main/java/com/jwoglom/pumpx2/pump/PumpState.java
@@ -20,6 +20,7 @@ import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import timber.log.Timber;
@@ -251,15 +252,69 @@ public class PumpState {
         }
     }
 
-    private static final Map<Pair<Characteristic, Byte>, PacketArrayList> savedPacketArrayList = new HashMap<>();
+    /**
+     * Key into {@link #savedPacketArrayList}. A plain value class rather than android.util.Pair:
+     * nothing here needs Android, and Pair is unavailable to JVM unit tests, which is why this
+     * map had no coverage.
+     */
+    private static final class PacketKey {
+        private final Characteristic characteristic;
+        private final byte txId;
+
+        PacketKey(Characteristic characteristic, byte txId) {
+            this.characteristic = characteristic;
+            this.txId = txId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof PacketKey)) return false;
+            PacketKey other = (PacketKey) o;
+            return txId == other.txId && characteristic == other.characteristic;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(characteristic, txId);
+        }
+
+        @Override
+        public String toString() {
+            return "PacketKey(" + characteristic + ", " + txId + ")";
+        }
+    }
+
+    private static final Map<PacketKey, PacketArrayList> savedPacketArrayList = new HashMap<>();
+
+    /**
+     * Stores a partially-accumulated response so the next BLE packet with the same transaction id
+     * can continue it.
+     *
+     * <p>Overwrites any existing entry rather than asserting the key is absent. A response
+     * spanning three or more packets re-saves the same accumulator once per packet, and
+     * transaction ids wrap at 256, so the same key legitimately recurs.
+     */
     public static synchronized void savePacketArrayList(Characteristic c, byte txId, PacketArrayList l) {
-        Pair<Characteristic, Byte> key = Pair.create(c, txId);
-        Validate.isTrue(!savedPacketArrayList.containsKey(key));
-        savedPacketArrayList.put(key, l);
+        savedPacketArrayList.put(new PacketKey(c, txId), l);
+    }
+
+    /**
+     * Discards the accumulator for a transaction, once it has produced a message or been given up
+     * on. Without this the entry outlives the response, and the next transaction to reuse the id
+     * -- 256 transactions later -- resumes into a stale, already-complete accumulator.
+     */
+    public static synchronized void removeSavedPacketArrayList(Characteristic c, byte txId) {
+        savedPacketArrayList.remove(new PacketKey(c, txId));
     }
 
     public static synchronized Optional<PacketArrayList> checkForSavedPacketArrayList(Characteristic c, byte txId) {
-        return Optional.ofNullable(savedPacketArrayList.get(Pair.create(c, txId)));
+        return Optional.ofNullable(savedPacketArrayList.get(new PacketKey(c, txId)));
+    }
+
+    // Visible for testing.
+    static synchronized int savedPacketArrayListSize() {
+        return savedPacketArrayList.size();
     }
 
     private static boolean actionsAffectingInsulinDeliveryEnabled = false;

--- a/androidLib/src/main/java/com/jwoglom/pumpx2/pump/bluetooth/TandemBluetoothHandler.java
+++ b/androidLib/src/main/java/com/jwoglom/pumpx2/pump/bluetooth/TandemBluetoothHandler.java
@@ -583,6 +583,10 @@ public class TandemBluetoothHandler {
                 Timber.d("Processed %s response (%d): %s (%s) (%d processed total, %d from us)", characteristic, txId, response.message(), Hex.encodeHexString(parser.getValue()), PumpState.processedResponseMessages, PumpState.processedResponseMessagesFromUs);
 
                 if (response.message().isPresent()) {
+                    // The accumulator has produced its message, so it must not be picked up by the
+                    // next transaction to reuse this txId. Only the error paths above keep theirs,
+                    // so a partial response can still continue.
+                    PumpState.removeSavedPacketArrayList(characteristic, txId);
                     if (!characteristicUUID.equals(CharacteristicUUID.HISTORY_LOG_CHARACTERISTICS) &&
                             !characteristicUUID.equals(CharacteristicUUID.CONTROL_STREAM_CHARACTERISTICS)) {
                         if (response.message().get() instanceof ErrorResponse) {
@@ -605,6 +609,9 @@ public class TandemBluetoothHandler {
                         PumpState.savePacketArrayList(characteristic, txId, packetArrayList);
                     } else {
                         Timber.w("Dropping unprocessable complete response message for '%s' (txId=%d, characteristic=%s)", Hex.encodeHexString(parser.getValue()), txId, characteristic);
+                        // Complete but unusable: nothing further will arrive for this txId, so the
+                        // accumulator would otherwise be left behind for the id to wrap onto.
+                        PumpState.removeSavedPacketArrayList(characteristic, txId);
                     }
                     return;
                 }

--- a/androidLib/src/test/java/com/jwoglom/pumpx2/pump/PumpStateSavedPacketArrayListTest.java
+++ b/androidLib/src/test/java/com/jwoglom/pumpx2/pump/PumpStateSavedPacketArrayListTest.java
@@ -1,0 +1,86 @@
+package com.jwoglom.pumpx2.pump;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.jwoglom.pumpx2.pump.messages.PacketArrayList;
+import com.jwoglom.pumpx2.pump.messages.bluetooth.Characteristic;
+
+import org.junit.Test;
+
+/**
+ * Covers the accumulator map's lifecycle directly. TandemBluetoothHandler's use of it needs a
+ * BLE peripheral, so it is not exercised here.
+ */
+public class PumpStateSavedPacketArrayListTest {
+
+    private static PacketArrayList accumulator() {
+        // opCode and cargo size are irrelevant here; only map identity is under test.
+        return new TestPacketArrayList();
+    }
+
+    private static class TestPacketArrayList extends PacketArrayList {
+        TestPacketArrayList() {
+            super((byte) 1, (byte) 0, (byte) 0, false);
+        }
+    }
+
+    @Test
+    public void testSaveIsIdempotentForTheSameTransaction() {
+        // A response spanning three or more packets re-saves the same accumulator once per
+        // packet. This used to assert the key was absent and threw on the second save.
+        PacketArrayList l = accumulator();
+        PumpState.savePacketArrayList(Characteristic.CURRENT_STATUS, (byte) 7, l);
+        PumpState.savePacketArrayList(Characteristic.CURRENT_STATUS, (byte) 7, l);
+
+        assertSame(l, PumpState.checkForSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 7).get());
+        PumpState.removeSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 7);
+    }
+
+    @Test
+    public void testSaveAcceptsAReusedTransactionId() {
+        // Transaction ids wrap at 256, so the same (characteristic, txId) key recurs for a
+        // genuinely new response.
+        PacketArrayList first = accumulator();
+        PacketArrayList second = accumulator();
+
+        PumpState.savePacketArrayList(Characteristic.CURRENT_STATUS, (byte) 9, first);
+        PumpState.savePacketArrayList(Characteristic.CURRENT_STATUS, (byte) 9, second);
+
+        assertSame(second, PumpState.checkForSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 9).get());
+        PumpState.removeSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 9);
+    }
+
+    @Test
+    public void testRemoveDropsTheEntry() {
+        PumpState.savePacketArrayList(Characteristic.CURRENT_STATUS, (byte) 11, accumulator());
+        assertTrue(PumpState.checkForSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 11).isPresent());
+
+        PumpState.removeSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 11);
+        assertEquals(0, PumpState.savedPacketArrayListSize());
+    }
+
+    @Test
+    public void testRemoveOfAnAbsentEntryIsANoOp() {
+        PumpState.removeSavedPacketArrayList(Characteristic.CONTROL, (byte) 33);
+        assertEquals(0, PumpState.savedPacketArrayListSize());
+    }
+
+    @Test
+    public void testEntriesAreScopedPerCharacteristic() {
+        PacketArrayList status = accumulator();
+        PacketArrayList control = accumulator();
+        PumpState.savePacketArrayList(Characteristic.CURRENT_STATUS, (byte) 4, status);
+        PumpState.savePacketArrayList(Characteristic.CONTROL, (byte) 4, control);
+
+        assertSame(status, PumpState.checkForSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 4).get());
+        assertSame(control, PumpState.checkForSavedPacketArrayList(Characteristic.CONTROL, (byte) 4).get());
+
+        PumpState.removeSavedPacketArrayList(Characteristic.CURRENT_STATUS, (byte) 4);
+        assertTrue(PumpState.checkForSavedPacketArrayList(Characteristic.CONTROL, (byte) 4).isPresent());
+
+        PumpState.removeSavedPacketArrayList(Characteristic.CONTROL, (byte) 4);
+        assertEquals(0, PumpState.savedPacketArrayListSize());
+    }
+}


### PR DESCRIPTION
Salvaged from #102, rebased onto `dev` and split so it stands alone. This is the largest of the split PRs — happy to narrow it if you'd rather.

## The problem

`PumpState.savedPacketArrayList` holds the partially-accumulated response for a `(characteristic, txId)` so the next BLE packet can continue it. Nothing ever removed an entry, and `savePacketArrayList` asserted the key was absent. Two consequences:

1. **A response spanning three or more packets throws.** The same accumulator is saved once per intermediate packet; the second save hits `Validate.isTrue(!savedPacketArrayList.containsKey(key))`.
2. **Completed responses leak their entry.** Transaction ids are a byte and wrap at 256, so a later transaction reusing the id resumes into a stale, already-complete accumulator — or trips the same assertion.

## The change

`savePacketArrayList` now overwrites. `TandemBluetoothHandler` removes the entry at the two points where the transaction is finished:

- when the accumulator has produced a message
- when a complete response is dropped as unprocessable

The **error paths deliberately keep theirs**, so a partial response can still continue after a parse failure. Those entries remain unbounded — this PR does not address that, matching what #102 listed under "not addressed".

## The `Pair` → `PacketKey` swap

The map key moves from `android.util.Pair` to a private `PacketKey` value class. Nothing about it needs Android, and `Pair` throws `"Method create in android.util.Pair not mocked"` under plain JVM unit tests — which is why this map had no coverage at all. `requestMessages` still uses `Pair` and is untouched.

If you'd prefer to keep `Pair` and take this untested, say so and I'll drop that part.

## Testing

`PumpStateSavedPacketArrayListTest` covers repeat saves, a reused transaction id, removal, removal of an absent key, and per-characteristic scoping.

- `./gradlew :androidLib:testDebugUnitTest` — **13 tests, 0 failures** (8 before these 5)
- `./gradlew :messages:test` and `:androidLib:compileDebugJavaWithJavac` — pass

`TandemBluetoothHandler`'s own use of the map needs a BLE peripheral, so it is not covered here.

---
_Generated by [Claude Code](https://claude.ai/code/session_019P29DrgdD6rrdZ7N7Vtv5k)_