### PR TITLE
fix: reject malformed input in Packetize instead of logging past it

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/Packetize.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/Packetize.java
@@ -10,6 +10,7 @@ import com.jwoglom.pumpx2.shared.Hex;
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.Validate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,16 +36,18 @@ public class Packetize {
     }
 
     public static List<Packet> packetize(Message message, byte[] authenticationKey, byte currentTxId) {
+        Validate.notNull(message, "packetize requires a message");
         return packetize(message, authenticationKey, currentTxId, determineMaxChunkSize(message));
     }
 
     public static List<Packet> packetize(Message message, byte[] authenticationKey, byte currentTxId, int maxChunkSize) {
-        if (message == null) {
-            L.e(TAG, "packetize has null message");
-        } else if (message.getCargo() == null) {
-            L.e(TAG, "packetize has null messagecargo messageName="+message.messageName());
-            L.e(TAG, "packetize has null messagecargo message="+message+" authKey="+Hex.encodeHexString(authenticationKey));
-        }
+        // These were logged and then execution continued into the dereference a few lines below,
+        // so the only thing the log added was a line above the NullPointerException. Rejecting
+        // here names the message that failed, and does not log the authentication key to do it.
+        Validate.notNull(message, "packetize requires a message");
+        Validate.notNull(message.getCargo(),
+                "packetize requires cargo, messageName=" + message.messageName());
+
         int length = 3 + message.getCargo().length;
         if (message.signed()) {
             length += 24;
@@ -97,6 +100,11 @@ public class Packetize {
 
 
     public static List<List<Byte>> partitionList(byte[] packetWithCRC, int partitionSize) {
+        // A non-positive size never satisfies the size check below, so every byte accumulated
+        // into one partition and the whole packet went out as a single unchunked Packet rather
+        // than failing. Reject it instead.
+        Validate.isTrue(partitionSize > 0, "partitionSize must be positive, got %d", partitionSize);
+
         List<List<Byte>> partitions = new ArrayList<>();
         List<Byte> subList = new ArrayList<>();
 

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/PacketizeTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/PacketizeTest.java
@@ -1,0 +1,66 @@
+package com.jwoglom.pumpx2.pump.messages;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.jwoglom.pumpx2.pump.messages.bluetooth.models.Packet;
+import com.jwoglom.pumpx2.pump.messages.request.currentStatus.ApiVersionRequest;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class PacketizeTest {
+
+    private static final byte[] EMPTY_KEY = new byte[0];
+
+    @Test
+    public void testPartitionListChunksEvenly() {
+        byte[] data = new byte[6];
+        assertEquals(3, Packetize.partitionList(data, 2).size());
+        assertEquals(2, Packetize.partitionList(data, 3).size());
+        // A trailing short partition is kept.
+        assertEquals(2, Packetize.partitionList(data, 4).size());
+        assertEquals(1, Packetize.partitionList(data, 6).size());
+        assertEquals(1, Packetize.partitionList(data, 100).size());
+        assertEquals(0, Packetize.partitionList(new byte[0], 4).size());
+    }
+
+    @Test
+    public void testPartitionListRejectsNonPositiveSize() {
+        // Previously these silently produced one unchunked partition holding the whole packet,
+        // which packetize then sent to the pump as a single Packet.
+        byte[] data = new byte[6];
+        assertThrows(IllegalArgumentException.class, () -> Packetize.partitionList(data, 0));
+        assertThrows(IllegalArgumentException.class, () -> Packetize.partitionList(data, -1));
+    }
+
+    @Test
+    public void testPacketizeRejectsNullMessage() {
+        // Both overloads: the three-arg one dereferenced the message in determineMaxChunkSize
+        // before reaching the four-arg one's checks.
+        assertThrows(NullPointerException.class,
+                () -> Packetize.packetize(null, EMPTY_KEY, (byte) 0));
+        assertThrows(NullPointerException.class,
+                () -> Packetize.packetize(null, EMPTY_KEY, (byte) 0, 18));
+    }
+
+    @Test
+    public void testPacketizeRejectsNullCargo() {
+        // Previously logged and then fell through into message.getCargo().length one line later.
+        assertThrows(NullPointerException.class,
+                () -> Packetize.packetize(new NullCargoRequest(), EMPTY_KEY, (byte) 0, 18));
+    }
+
+    private static class NullCargoRequest extends ApiVersionRequest {
+        NullCargoRequest() {
+            this.cargo = null;
+        }
+    }
+
+    @Test
+    public void testPacketizeStillChunksANormalMessage() {
+        List<Packet> packets = Packetize.packetize(new ApiVersionRequest(), EMPTY_KEY, (byte) 0, 18);
+        assertEquals(1, packets.size());
+    }
+}


### PR DESCRIPTION
Salvaged from #102, rebased onto `dev` and split so it stands alone.

## Null message / null cargo

`packetize` logged `"has null message"` / `"has null messagecargo"` and then carried straight on to `message.getCargo().length` two lines later, so the only effect of the logging was a line above the `NullPointerException` it did not prevent.

Both cases are now rejected up front, with the message name in the failure. The null-cargo path also stops hex-encoding the authentication key into a log line to report the failure.

The three-argument overload gets the same check: it passed the message to `determineMaxChunkSize` before the four-argument overload could inspect it.

## `partitionList` and non-positive sizes

The size check inside the loop is an equality test, so a non-positive `partitionSize` never matched — every byte accumulated into a single partition, and `packetize` emitted the whole packet as one unchunked `Packet` rather than failing. It now validates the argument.

(Contrary to how #102 described this, it did **not** spin — the loop is bounded by the input array.)

## Not included

The `L.d(TAG, "using authenticationKey=" + ...)` line further down is untouched; the broader secrets-in-logs question from #102 is deliberately out of scope here.

## Testing

Adds `PacketizeTest` covering even and short-tailed chunking, the empty input, the rejected partition sizes, both null-message overloads and null cargo.

- `./gradlew :messages:test` — **678 tests, 0 failures** (673 before these 5)
- `./gradlew :androidLib:compileDebugJavaWithJavac :androidLib:testDebugUnitTest` — pass

---
_Generated by [Claude Code](https://claude.ai/code/session_019P29DrgdD6rrdZ7N7Vtv5k)_