### PR TITLE
PumpingSuspendedHistoryLog: document insulinAmount as reservoir remaining, add Mobi fixtures

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLog.java
@@ -59,24 +59,24 @@ public class PumpingSuspendedHistoryLog extends HistoryLog {
 
     /**
      * @return the state of the pump immediately before pumping was suspended
-     * (Tandem's pump-logs JSON calls this property preSuspendState)
+     * (Tandem's pump-logs JSON calls this property preSuspendState).
+     * 106 in every record observed so far across t:slim X2 and Mobi, for both user-initiated
+     * and alarm-triggered suspends; no other value has been seen.
      */
     public long getPreSuspendState() {
         return preSuspendState;
     }
 
     /**
-     * @return an insulin reservoir quantity, in whole units, at the time pumping was suspended.
-     * This is NOT the IOB: the value is byte-identical in the paired suspended and resumed
-     * records which bracket a suspension, while the IOB the pump reports in LID_DAILY_BASAL
-     * over the same window decays.
-     *
-     * TODO: determine whether this is the insulin remaining in the reservoir or the current
-     * cartridge fill level. Observed captures support both readings and the question is
-     * unresolved: one suspend/resume pair drops 120 -> 105 across a 15 minute suspension
-     * (consistent with remaining volume being consumed by a tubing prime), while another
-     * capture reads 180 at a suspend roughly ten hours after a 180 unit cartridge fill
-     * (which remaining volume should have decremented by then).
+     * @return the insulin remaining in the reservoir as the pump reports it at the instant
+     * pumping was suspended, in whole units. This is the same number
+     * {@code InsulinStatusResponse.currentInsulinAmount} returns: on a Mobi capture the two were
+     * byte-identical when the status was polled within two seconds of the record, in 4 of 4
+     * suspends and 4 of 4 resumes. It is not the cartridge fill level (it dropped 110 -> 90
+     * across a tubing fill on the same cartridge) and it is not the IOB (the IOB the pump reports
+     * in LID_DAILY_BASAL decays over a suspension while this value does not). The paired
+     * suspended and resumed records which bracket a suspension carry the same value when nothing
+     * was delivered in between.
      */
     public int getInsulinAmount() {
         return insulinAmount;
@@ -91,6 +91,9 @@ public class PumpingSuspendedHistoryLog extends HistoryLog {
     /**
      * @return the resume pump alert (RPA) timeout in minutes: how long the pump waits while
      * suspended before alerting that insulin delivery is still stopped. 0 when unset.
+     * The value 15 was observed on every suspend in a Mobi capture, and the suspensions that
+     * lasted longer than 15 minutes each raised RESUME_PUMP_ALARM (18) and RESUME_PUMP_ALARM2 (23)
+     * 15 min 1 s after the suspend, confirming the unit is minutes.
      * (Tandem's pump-logs JSON calls this property rpaTimeout)
      */
     public int getRpaTimeout() {

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLogTest.java
@@ -92,6 +92,52 @@ public class PumpingSuspendedHistoryLogTest {
         assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
     }
 
+    // Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture.
+    // InsulinStatusResponse.currentInsulinAmount polled within two seconds of each record returned
+    // the same insulinAmount (150 and 8), and the suspension that followed the first record ran
+    // past 15 minutes and raised RESUME_PUMP_ALARM / RESUME_PUMP_ALARM2 at 15 min 1 s.
+    @Test
+    public void testPumpingSuspendedHistoryLogMobiReservoir150() throws DecoderException {
+        PumpingSuspendedHistoryLog expected = (PumpingSuspendedHistoryLog) new PumpingSuspendedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preSuspendState, int insulinAmount, int reason, int rpaTimeout
+                589553316L, 641936L, 106, 150, 0, 15
+        ).withHeaderHighNibble(1);
+
+        PumpingSuspendedHistoryLog parsedRes = (PumpingSuspendedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0b10a4de232390cb09006a0000009600000f0000000000000000",
+                expected
+        );
+        assertEquals(589553316L, parsedRes.getPumpTimeSec());
+        assertEquals(641936L, parsedRes.getSequenceNum());
+        assertEquals(106L, parsedRes.getPreSuspendState());
+        assertEquals(150, parsedRes.getInsulinAmount());
+        assertEquals(0, parsedRes.getReasonId());
+        assertEquals(PumpingSuspendedHistoryLog.SuspendReason.USER_ABORTED, parsedRes.getReason());
+        assertEquals(15, parsedRes.getRpaTimeout());
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
+    @Test
+    public void testPumpingSuspendedHistoryLogMobiReservoir8() throws DecoderException {
+        PumpingSuspendedHistoryLog expected = (PumpingSuspendedHistoryLog) new PumpingSuspendedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preSuspendState, int insulinAmount, int reason, int rpaTimeout
+                589745484L, 651659L, 106, 8, 0, 15
+        ).withHeaderHighNibble(1);
+
+        PumpingSuspendedHistoryLog parsedRes = (PumpingSuspendedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0b104ccd26238bf109006a0000000800000f0000000000000000",
+                expected
+        );
+        assertEquals(589745484L, parsedRes.getPumpTimeSec());
+        assertEquals(651659L, parsedRes.getSequenceNum());
+        assertEquals(106L, parsedRes.getPreSuspendState());
+        assertEquals(8, parsedRes.getInsulinAmount());
+        assertEquals(0, parsedRes.getReasonId());
+        assertEquals(PumpingSuspendedHistoryLog.SuspendReason.USER_ABORTED, parsedRes.getReason());
+        assertEquals(15, parsedRes.getRpaTimeout());
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
     /**
      * The upper nibble of the second typeId byte identifies the source of the log entry and is
      * not part of the typeId itself (parseBase masks it off with & 4095). buildCargo() has no


### PR DESCRIPTION
Refs jwoglom/pumpX2#39

## Summary

Javadoc-only change to `PumpingSuspendedHistoryLog` (opcode 11, `LID_PUMPING_SUSPENDED`) plus two new fixtures from an observed Mobi capture. No layout or parsing change.

- **`getInsulinAmount()`**: replaced the TODO with a factual description. The field is the insulin remaining in the reservoir as the pump reports it at that instant, in whole units, i.e. the same number `InsulinStatusResponse.currentInsulinAmount` returns. It is not the cartridge fill level and not IOB. Kept the note that paired suspend/resume records match when nothing was delivered in between.
- **`getRpaTimeout()`**: added the observed value and the alarm timing that confirms the unit is minutes.
- **`getPreSuspendState()`**: added that 106 is the only value seen so far across X2 and Mobi, user and alarm suspends.

## Evidence

From a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture, four `PumpingSuspended` records with the pump's `InsulinStatusResponse` polled within two seconds of each:

| insulinAmount@14 | `currentInsulinAmount` | reason | rpaTimeout |
| --- | --- | --- | --- |
| 150 | 150 | 0 | 15 |
| 110 | 110 | 0 | 15 |
| 65 | 65 | 0 | 15 |
| 8 | 8 | 0 | 15 |

- `insulinAmount` matched the live status in 4/4 suspends and 4/4 paired resumes.
- Not fill level: it dropped 110 -> 90 across a tubing fill on the same cartridge (live status went 110 -> 100 -> 90 during the prime), and jumped 8 -> 185 across a cartridge change.
- `rpaTimeout` was 15 on all four; the two suspensions that lasted longer than 15 minutes each raised `RESUME_PUMP_ALARM` (18) and `RESUME_PUMP_ALARM2` (23) exactly 15 min 1 s after the suspend.
- `preSuspendState` was 106 in all four, matching the existing X2 fixtures including the alarm-triggered one.

## Tests

Added to the existing `PumpingSuspendedHistoryLogTest`:

- `testPumpingSuspendedHistoryLogMobiReservoir150` (payload `0b10a4de232390cb09006a0000009600000f0000000000000000`)
- `testPumpingSuspendedHistoryLogMobiReservoir8` (payload `0b104ccd26238bf109006a0000000800000f0000000000000000`)

Both are full-record tests (`HistoryLogMessageTester.testSingle` with real `pumpTimeSec`/`sequenceNum` decoded from the hex and `.withHeaderHighNibble(1)`), asserting `insulinAmount`, `reasonId` 0 / `USER_ABORTED`, `rpaTimeout` 15, `preSuspendState` 106 and the exact cargo round trip.

Executed locally: `./gradlew :messages:test --tests '*PumpingSuspendedHistoryLogTest*' --offline --no-daemon -q` passed, 7 tests, 0 failures (5 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_