### PR TITLE
PumpingResumedHistoryLog: document insulinAmount as reservoir remaining, add Mobi fixtures

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLog.java
@@ -54,24 +54,30 @@ public class PumpingResumedHistoryLog extends HistoryLog {
 
     /**
      * @return the state of the pump immediately before pumping was resumed
-     * (Tandem's pump-logs JSON calls this property preResumeState)
+     * (Tandem's pump-logs JSON calls this property preResumeState).
+     * Observed as 100 in every record captured so far, across both t:slim X2 and Mobi;
+     * no other value has been seen.
      */
     public long getPreResumeState() {
         return preResumeState;
     }
 
     /**
-     * @return an insulin reservoir quantity, in whole units, at the time pumping was resumed.
-     * This is NOT the IOB: the value is byte-identical in the paired suspended and resumed
-     * records which bracket a suspension, while the IOB the pump reports in LID_DAILY_BASAL
-     * over the same window decays.
+     * @return the insulin remaining in the reservoir, in whole units, as the pump reports it at
+     * the instant pumping was resumed. This is the same figure as
+     * {@code InsulinStatusResponse.currentInsulinAmount}: in a Mobi capture the value was
+     * byte-identical to that response polled within two seconds in 4 of 4 resumes (and in 4 of 4
+     * suspends for the paired {@link PumpingSuspendedHistoryLog}).
      *
-     * TODO: determine whether this is the insulin remaining in the reservoir or the current
-     * cartridge fill level. Observed captures support both readings and the question is
-     * unresolved: one suspend/resume pair drops 120 -> 105 across a 15 minute suspension
-     * (consistent with remaining volume being consumed by a tubing prime), while another
-     * capture reads 180 at a suspend roughly ten hours after a 180 unit cartridge fill
-     * (which remaining volume should have decremented by then).
+     * It is the remaining amount, not the cartridge fill level: after a tubing fill on the same
+     * cartridge the resume read 90 where the paired suspend had read 110 (the prime consumed
+     * insulin), and after a cartridge change the resume read 185 (equal to
+     * {@code CartridgeFilledHistoryLog.insulinDisplay} logged in the same second) where the
+     * paired suspend had read 8.
+     *
+     * It is also NOT the IOB: across a suspension with no fill the value is identical in the
+     * paired suspended and resumed records, while the IOB the pump reports in LID_DAILY_BASAL
+     * over the same window decays.
      */
     public int getInsulinAmount() {
         return insulinAmount;

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLogTest.java
@@ -59,4 +59,54 @@ public class PumpingResumedHistoryLogTest {
         assertEquals(105, parsedRes.getInsulinAmount());
         assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
     }
+
+    // The two tests below parse records observed on a Tandem Mobi driven by Trio (Control-IQ off,
+    // no CGM paired), Sept 2026 BLE capture. In both, insulinAmount matched
+    // InsulinStatusResponse.currentInsulinAmount polled within two seconds of the resume.
+
+    /**
+     * Resume following a cartridge change: the paired PumpingSuspended record read 8 units, and
+     * CartridgeFilledHistoryLog.insulinDisplay logged in the same second was 185. insulinAmount
+     * is therefore the remaining reservoir amount rather than a value carried over from suspend.
+     */
+    @Test
+    public void testPumpingResumedHistoryLogAfterCartridgeChangeMobi() throws DecoderException {
+        PumpingResumedHistoryLog expected = new PumpingResumedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preResumeState, int insulinAmount
+                589745836L, 651756L, 100, 185
+        );
+
+        PumpingResumedHistoryLog parsedRes = (PumpingResumedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0c10acce2623ecf1090064000000b90000000000000000000000",
+                expected
+        );
+        assertEquals(589745836L, parsedRes.getPumpTimeSec());
+        assertEquals(651756L, parsedRes.getSequenceNum());
+        assertEquals(100L, parsedRes.getPreResumeState());
+        assertEquals(185, parsedRes.getInsulinAmount());
+        assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
+    }
+
+    /**
+     * Resume following a tubing fill on the same cartridge: the paired PumpingSuspended record
+     * read 110 units and the live InsulinStatusResponse dropped 110 -> 100 -> 90 during the prime,
+     * so the resume records the post-prime remaining amount of 90.
+     */
+    @Test
+    public void testPumpingResumedHistoryLogAfterTubingFillMobi() throws DecoderException {
+        PumpingResumedHistoryLog expected = new PumpingResumedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, long preResumeState, int insulinAmount
+                589585424L, 643715L, 100, 90
+        );
+
+        PumpingResumedHistoryLog parsedRes = (PumpingResumedHistoryLog) HistoryLogMessageTester.testSingle(
+                "0c10105c242383d20900640000005a0000000000000000000000",
+                expected
+        );
+        assertEquals(589585424L, parsedRes.getPumpTimeSec());
+        assertEquals(643715L, parsedRes.getSequenceNum());
+        assertEquals(100L, parsedRes.getPreResumeState());
+        assertEquals(90, parsedRes.getInsulinAmount());
+        assertHexEquals(expected.getCargo(), withoutSourceNibble(parsedRes.getCargo()));
+    }
 }


### PR DESCRIPTION
Refs jwoglom/pumpX2#40

## Summary

Javadoc-only change to `PumpingResumedHistoryLog` (opCode 12, `LID_PUMPING_RESUMED`); no layout or parsing change.

- `getInsulinAmount()`: replaces the TODO with a factual description. The uint16 at bytes 14-15 is the insulin remaining in the reservoir, in whole units, as the pump reports it at the instant pumping resumed (the same figure as `InsulinStatusResponse.currentInsulinAmount`). It is the remaining amount, not the cartridge fill level, and not IOB.
- `getPreResumeState()`: notes that only the value 100 has been observed, across both t:slim X2 and Mobi.
- The `buildCargo` comment did not describe the uint32 at 10-13 as "unknown" on `dev`, so nothing to fix there.

## Evidence

From a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture, four PumpingResumed records each with an `InsulinStatusResponse` polled within two seconds:

- `insulinAmount` equalled `InsulinStatusResponse.currentInsulinAmount` in 4 of 4 resumes (150, 90, 65, 185), and in 4 of 4 of the paired suspends (see #39).
- Resume after a tubing fill on the same cartridge read **90** where the paired suspend read **110** (live status dropped 110 -> 100 -> 90 during the prime) — so the value is consumed by a prime, i.e. remaining volume, not fill level.
- Resume after a cartridge change read **185**, equal to `CartridgeFilledHistoryLog.insulinDisplay` logged in the same second, where the paired suspend read **8**.
- `preResumeState` = 100 in all four records, matching the existing fixtures; no other value seen.

## Tests

Appended two full-record tests to the existing `PumpingResumedHistoryLogTest`, following the file's existing pattern (`HistoryLogMessageTester.testSingle` + `withoutSourceNibble` cargo round trip), with pumpTimeSec/sequenceNum decoded from the hex:

- `testPumpingResumedHistoryLogAfterCartridgeChangeMobi` — `0c10acce2623ecf1090064000000b90000000000000000000000`: pumpTimeSec 589745836, sequenceNum 651756, preResumeState 100, insulinAmount 185
- `testPumpingResumedHistoryLogAfterTubingFillMobi` — `0c10105c242383d20900640000005a0000000000000000000000`: pumpTimeSec 589585424, sequenceNum 643715, preResumeState 100, insulinAmount 90

Executed locally: `./gradlew :messages:test --tests '*PumpingResumedHistoryLogTest*' --offline --no-daemon -q` — 5 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_