### PR TITLE
BolusRequestedMsg2HistoryLog: mark BLE_STANDARD option as verified, add Mobi fixture

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLog.java
@@ -120,15 +120,23 @@ public class BolusRequestedMsg2HistoryLog extends HistoryLog {
     /**
      * How the bolus was requested.
      *
-     * <p><b>Value names ported from the tconnectsync Python implementation and not verified
-     * here.</b> No record committed to this repository exercises them. Confirm against a capture
-     * before relying on these labels.
+     * <p><b>Value names ported from the tconnectsync Python implementation.</b> Only
+     * {@link #BLE_STANDARD} (4) has been confirmed on the wire so far (see
+     * <a href="https://github.com/jwoglom/pumpX2/issues/51">issue 51</a>): in a capture of
+     * 156 boluses initiated over BLE by a remote app ({@code InitiateBolusRequest}; the paired
+     * {@link BolusDeliveryHistoryLog} reported {@code bolusSource = 8}), 156/156
+     * LID_BOLUS_REQUESTED_MSG2 records carried {@code options = 4} together with
+     * {@code standardPercent = 100}, {@code duration = 0}, {@code userOverride = true} and
+     * {@code isf = targetBG = 0}. The remaining values are still tconnectsync-sourced and
+     * unverified: no record committed to this repository exercises them, so confirm against a
+     * capture before relying on those labels.
      */
     public enum BolusOption {
         STANDARD(0),
         EXTENDED(1),
         QUICK(2),
         AUTOMATIC(3),
+        /** Verified on the wire: 156/156 BLE-initiated boluses in the issue 51 capture. */
         BLE_STANDARD(4),
         BLE_EXTENDED(5),
         EATING_SOON_AUTOMATIC(6),

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg2HistoryLogTest.java
@@ -1,6 +1,9 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.jwoglom.pumpx2.pump.messages.MessageTester;
 import com.jwoglom.pumpx2.pump.messages.bluetooth.CharacteristicUUID;
@@ -57,6 +60,38 @@ public class BolusRequestedMsg2HistoryLogTest {
                 expected
         );
 
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
+    // Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture.
+    // Bolus initiated over BLE via InitiateBolusRequest (bolusSource = 8 in the paired
+    // BolusDeliveryHistoryLog). options = 4 (BLE_STANDARD) was seen in 156/156 such boluses, with
+    // standardPercent 100, duration 0, userOverride true and isf/targetBG 0 (no calculator inputs
+    // are sent over BLE). Header high nibble is 1 on this pump. See jwoglom/pumpX2#51.
+    @Test
+    public void testBolusRequestedMsg2HistoryLog_bleStandard() throws DecoderException {
+        BolusRequestedMsg2HistoryLog expected = new BolusRequestedMsg2HistoryLog(
+                // long pumpTimeSec, long sequenceNum, int bolusId, int options, int standardPercent, int duration, int spare1, int isf, int targetBG, boolean userOverride, boolean declinedCorrection, int selectedIOB, int spare2, int headerHighNibble
+                589526830L, 640747L, 2903, 4, 100, 0, 0, 0, 0, true, false, 0, 0, 1
+        );
+
+        BolusRequestedMsg2HistoryLog parsedRes = (BolusRequestedMsg2HistoryLog) HistoryLogMessageTester.testSingle(
+                "41102e772323ebc60900570b0464000000000000000001000000",
+                expected
+        );
+
+        assertEquals(1, parsedRes.getHeaderHighNibble());
+        assertEquals(2903, parsedRes.getBolusId());
+        assertEquals(4, parsedRes.getOptions());
+        assertEquals(BolusRequestedMsg2HistoryLog.BolusOption.BLE_STANDARD, parsedRes.getBolusOption());
+        assertEquals(100, parsedRes.getStandardPercent());
+        assertEquals(0, parsedRes.getDuration());
+        assertEquals(0, parsedRes.getIsf());
+        assertEquals(0, parsedRes.getTargetBG());
+        assertTrue(parsedRes.getUserOverride());
+        assertFalse(parsedRes.getDeclinedCorrection());
+        assertEquals(0, parsedRes.getSelectedIOB());
+        assertEquals(BolusRequestedMsg2HistoryLog.SelectedIOBType.MUDALIAR_IOB, parsedRes.getSelectedIOBType());
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }


### PR DESCRIPTION
Refs jwoglom/pumpX2#51

## Summary

Javadoc-only change to `BolusRequestedMsg2HistoryLog.BolusOption` (opCode 65, `LID_BOLUS_REQUESTED_MSG2`), plus one new test fixture. No layout or parsing change.

The `BolusOption` enum javadoc said every value name was ported from tconnectsync and unverified. This PR amends it to say that `BLE_STANDARD` (4) is now confirmed on the wire, and adds a one-line javadoc on the `BLE_STANDARD` constant itself. The other values (0-3, 5-7) remain tconnectsync-sourced and unverified, and the javadoc still says so.

## Evidence

Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture:

- 156 boluses initiated over BLE by a remote app (`InitiateBolusRequest`; `bolusSource = 8` in the paired `BolusDeliveryHistoryLog`).
- 156/156 `LID_BOLUS_REQUESTED_MSG2` records carried `options = 4`, with `standardPercent = 100`, `duration = 0`, `userOverride = true`, `isf = 0`, `targetBG = 0`, `declinedCorrection = false`, `selectedIOB = 0` (`selectedIOB` matched byte 12 of the paired `BolusActivated` in 156/156).
- No pump-GUI, quick, extended or Control-IQ boluses were in the capture, so the remaining `BolusOption` values were not exercised.

Fixture record: `41102e772323ebc60900570b0464000000000000000001000000` (header high nibble 1, pumpTimeSec 589526830, sequenceNum 640747, bolusId 2903).

## Tests

Added `BolusRequestedMsg2HistoryLogTest.testBolusRequestedMsg2HistoryLog_bleStandard`, following the existing pattern in that file (`HistoryLogMessageTester.testSingle` + cargo round trip via `assertHexEquals`), using the `headerHighNibble`-taking constructor. It asserts `getBolusOption() == BolusOption.BLE_STANDARD`, `getOptions() == 4`, `standardPercent == 100`, `userOverride == true`, `declinedCorrection == false`, `selectedIOB == 0`, `duration/isf/targetBG == 0`, and `getHeaderHighNibble() == 1`.

Executed locally:

```
./gradlew :messages:test --tests '*BolusRequestedMsg2HistoryLogTest*' --offline --no-daemon -q
```

Result: 4 tests, 0 failures, 0 errors (3 pre-existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_