### PR TITLE
BasalDeliveryHistoryLog: decode bytes 12-13 and add CommandedRateSource enum

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLog.java
@@ -15,21 +15,27 @@ import java.math.BigInteger;
 public class BasalDeliveryHistoryLog extends HistoryLog {
     
     private int commandedRateSource;
+    private int basalDeliveryFlags;
     private int commandedRate;
     private int profileBasalRate;
     private int algorithmRate;
     private int tempRate;
     
     public BasalDeliveryHistoryLog() {}
-    public BasalDeliveryHistoryLog(long pumpTimeSec, long sequenceNum, int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
+    public BasalDeliveryHistoryLog(long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
         super(pumpTimeSec, sequenceNum);
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, commandedRateSource, commandedRate, profileBasalRate, algorithmRate, tempRate);
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, commandedRateSource, basalDeliveryFlags, commandedRate, profileBasalRate, algorithmRate, tempRate);
         this.commandedRateSource = commandedRateSource;
+        this.basalDeliveryFlags = basalDeliveryFlags;
         this.commandedRate = commandedRate;
         this.profileBasalRate = profileBasalRate;
         this.algorithmRate = algorithmRate;
         this.tempRate = tempRate;
         
+    }
+
+    public BasalDeliveryHistoryLog(long pumpTimeSec, long sequenceNum, int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
+        this(pumpTimeSec, sequenceNum, commandedRateSource, 0, commandedRate, profileBasalRate, algorithmRate, tempRate);
     }
 
     public BasalDeliveryHistoryLog(int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
@@ -45,6 +51,7 @@ public class BasalDeliveryHistoryLog extends HistoryLog {
         this.cargo = raw;
         parseBase(raw);
         this.commandedRateSource = Bytes.readShort(raw, 10);
+        this.basalDeliveryFlags = Bytes.readShort(raw, 12);
         this.commandedRate = Bytes.readShort(raw, 14);
         this.profileBasalRate = Bytes.readShort(raw, 16);
         this.algorithmRate = Bytes.readShort(raw, 18);
@@ -52,20 +59,40 @@ public class BasalDeliveryHistoryLog extends HistoryLog {
         
     }
 
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
         return HistoryLog.fillCargo(Bytes.combine(
             HistoryLog.typeIdBytes(279, 0), // 279 = 256 + 23 (byte1 must be 1, not 0)
             Bytes.toUint32(pumpTimeSec),
             Bytes.toUint32(sequenceNum),
             Bytes.firstTwoBytesLittleEndian(commandedRateSource),
-            new byte[2],
+            Bytes.firstTwoBytesLittleEndian(basalDeliveryFlags),
             Bytes.firstTwoBytesLittleEndian(commandedRate),
             Bytes.firstTwoBytesLittleEndian(profileBasalRate), 
             Bytes.firstTwoBytesLittleEndian(algorithmRate), 
             Bytes.firstTwoBytesLittleEndian(tempRate)));
     }
+
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int commandedRateSource, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate) {
+        return buildCargo(pumpTimeSec, sequenceNum, commandedRateSource, 0, commandedRate, profileBasalRate, algorithmRate, tempRate);
+    }
+
     public int getCommandedRateSource() {
         return commandedRateSource;
+    }
+
+    /**
+     * Raw value of bytes 12-13. Tandem's export does not name this field, so it is exposed as-is.
+     *
+     * <p>Only the values 0 and 3 have been observed, across roughly 49k records in two captures.
+     * 3 is written when any rate field changed versus the previous record, or when a
+     * TempRateActivated / TempRateCompleted / PumpingSuspended / PumpingResumed occurred in the
+     * 5-minute interval, and in nearly every record written while suspended. 0 is written for
+     * steady-state delivery. It is not a temp-rate indicator: it reads 0 in most records with an
+     * active temp rate. The meaning of the two individual bits is unknown; they have never been
+     * seen set independently. See https://github.com/jwoglom/pumpx2/issues/77.
+     */
+    public int getBasalDeliveryFlags() {
+        return basalDeliveryFlags;
     }
     public int getCommandedRate() {
         return commandedRate;
@@ -78,6 +105,47 @@ public class BasalDeliveryHistoryLog extends HistoryLog {
     }
     public int getTempRate() {
         return tempRate;
+    }
+
+    /**
+     * Source of {@code commandedRate} (bytes 10-11).
+     *
+     * <p>Values 0, 1 and 2 are confirmed on the wire in a Control-IQ-off capture: for 2,
+     * {@code commandedRate == tempRate} in 768/768 records; for 0, the pump was suspended with
+     * {@code commandedRate} 0 and {@code tempRate}/{@code algorithmRate} both 0xFFFF in 20/20
+     * records; for 1, {@code commandedRate == profileBasalRate} in 10/10 records. 3 was observed
+     * in an earlier Control-IQ capture, where it predicted {@code algorithmRate != 0xFFFF}.
+     * 4 comes from Tandem's export value map and has not yet been observed.
+     * See https://github.com/jwoglom/pumpx2/issues/77.
+     */
+    public enum CommandedRateSource {
+        SUSPENDED(0),
+        PROFILE(1),
+        TEMP_RATE(2),
+        ALGORITHM(3),
+        TEMP_RATE_AND_ALGORITHM(4),
+        ;
+
+        private int id;
+        CommandedRateSource(int id) {
+            this.id = id;
+        }
+        public int id() {
+            return id;
+        }
+        public static CommandedRateSource fromId(int id) {
+            for (CommandedRateSource s : values()) {
+                if (s.id == id) return s;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * @return the {@link CommandedRateSource} for {@code commandedRateSource}, or null if unknown
+     */
+    public CommandedRateSource getCommandedRateSourceEnum() {
+        return CommandedRateSource.fromId(commandedRateSource);
     }
     
 }

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLogTest.java
@@ -1,14 +1,17 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 
 public class BasalDeliveryHistoryLogTest {
-    // Bytes 12-13 carry an as-yet-unidentified field in ~58% of captured LID_BASAL_DELIVERY
-    // records (no reference source defines them); these fixtures use captures where those bytes
-    // are zero so the round-trip below is honest.
+    // Bytes 12-13 are decoded as basalDeliveryFlags (see BasalDeliveryHistoryLog#getBasalDeliveryFlags
+    // and https://github.com/jwoglom/pumpx2/issues/77). The first three fixtures below predate that
+    // and carry 0 there, so they use the constructor without the flags argument; the later fixtures
+    // exercise the flags = 3 case directly.
     @Test
     public void testBasalDeliveryHistoryLog1() throws DecoderException {
         BasalDeliveryHistoryLog expected = (BasalDeliveryHistoryLog) new BasalDeliveryHistoryLog(
@@ -21,6 +24,8 @@ public class BasalDeliveryHistoryLogTest {
                 expected
         );
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(0, parsedRes.getBasalDeliveryFlags());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.ALGORITHM, parsedRes.getCommandedRateSourceEnum());
     }
 
     @Test
@@ -35,6 +40,8 @@ public class BasalDeliveryHistoryLogTest {
                 expected
         );
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(0, parsedRes.getBasalDeliveryFlags());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.PROFILE, parsedRes.getCommandedRateSourceEnum());
     }
 
     @Test
@@ -50,5 +57,145 @@ public class BasalDeliveryHistoryLogTest {
                 expected
         );
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(0, parsedRes.getBasalDeliveryFlags());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.SUSPENDED, parsedRes.getCommandedRateSourceEnum());
+    }
+
+    // The fixtures below were observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM
+    // paired), Sept 2026 BLE capture. Bytes 12-13 read 3 whenever a rate field changed or a
+    // temp-rate/suspend/resume event fell in the preceding 5-minute interval, and 0 for
+    // steady-state delivery.
+
+    @Test
+    public void testBasalDeliveryHistoryLog_tempRateStart_flags3() throws DecoderException {
+        // temp rate 160% (1600 mU/hr on a 1000 mU/hr profile) activated in the interval
+        BasalDeliveryHistoryLog expected = (BasalDeliveryHistoryLog) new BasalDeliveryHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            589526924L, 640766L, 2, 3, 1600, 1000, 65535, 1600
+        ).withHeaderHighNibble(1);
+
+        BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "17118c772323fec60900020003004006e803ffff400600000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(2, parsedRes.getCommandedRateSource());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.TEMP_RATE, parsedRes.getCommandedRateSourceEnum());
+        assertEquals(3, parsedRes.getBasalDeliveryFlags());
+        assertEquals(1600, parsedRes.getCommandedRate());
+        assertEquals(1000, parsedRes.getProfileBasalRate());
+        assertEquals(65535, parsedRes.getAlgorithmRate());
+        assertEquals(1600, parsedRes.getTempRate());
+    }
+
+    @Test
+    public void testBasalDeliveryHistoryLog_tempRateZero_flags3() throws DecoderException {
+        // temp rate changed to 0% in the interval
+        BasalDeliveryHistoryLog expected = (BasalDeliveryHistoryLog) new BasalDeliveryHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            589527224L, 640778L, 2, 3, 0, 1000, 65535, 0
+        ).withHeaderHighNibble(1);
+
+        BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "1711b87823230ac70900020003000000e803ffff000000000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.TEMP_RATE, parsedRes.getCommandedRateSourceEnum());
+        assertEquals(3, parsedRes.getBasalDeliveryFlags());
+        assertEquals(0, parsedRes.getCommandedRate());
+        assertEquals(0, parsedRes.getTempRate());
+    }
+
+    @Test
+    public void testBasalDeliveryHistoryLog_tempRateSteadyState_flags0() throws DecoderException {
+        // same 0% temp rate still active, nothing changed: flags are 0 even though a temp rate is active
+        BasalDeliveryHistoryLog expected = (BasalDeliveryHistoryLog) new BasalDeliveryHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            589527525L, 640786L, 2, 0, 0, 1000, 65535, 0
+        ).withHeaderHighNibble(1);
+
+        BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "1711e579232312c70900020000000000e803ffff000000000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.TEMP_RATE, parsedRes.getCommandedRateSourceEnum());
+        assertEquals(0, parsedRes.getBasalDeliveryFlags());
+        assertEquals(0, parsedRes.getCommandedRate());
+        assertEquals(0, parsedRes.getTempRate());
+    }
+
+    @Test
+    public void testBasalDeliveryHistoryLog_tempRateActiveSteadyState_flags0() throws DecoderException {
+        // 90% temp rate (900 mU/hr) active and unchanged: flags 0 with commandedRate == tempRate
+        BasalDeliveryHistoryLog expected = (BasalDeliveryHistoryLog) new BasalDeliveryHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            589535633L, 641098L, 2, 0, 900, 1000, 65535, 900
+        ).withHeaderHighNibble(1);
+
+        BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "1711919923234ac80900020000008403e803ffff840300000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.TEMP_RATE, parsedRes.getCommandedRateSourceEnum());
+        assertEquals(0, parsedRes.getBasalDeliveryFlags());
+        assertEquals(900, parsedRes.getCommandedRate());
+        assertEquals(900, parsedRes.getTempRate());
+    }
+
+    @Test
+    public void testBasalDeliveryHistoryLog_profileSegmentChange_flags3() throws DecoderException {
+        // first record after the 08:00 profile segment change (1000 -> 1200 mU/hr) with a 90% temp rate active:
+        // flags are 3 because profileBasalRate changed, with no temp-rate event in the interval
+        BasalDeliveryHistoryLog expected = (BasalDeliveryHistoryLog) new BasalDeliveryHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            589536234L, 641124L, 2, 3, 1080, 1200, 65535, 1080
+        ).withHeaderHighNibble(1);
+
+        BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "1711ea9b232364c80900020003003804b004ffff380400000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.TEMP_RATE, parsedRes.getCommandedRateSourceEnum());
+        assertEquals(3, parsedRes.getBasalDeliveryFlags());
+        assertEquals(1080, parsedRes.getCommandedRate());
+        assertEquals(1200, parsedRes.getProfileBasalRate());
+        assertEquals(1080, parsedRes.getTempRate());
+    }
+
+    @Test
+    public void testBasalDeliveryHistoryLog_suspended_flags3() throws DecoderException {
+        // suspended: commandedRateSource 0, commandedRate 0, algorithm/temp rate both "n/a" (0xffff), flags 3
+        BasalDeliveryHistoryLog expected = (BasalDeliveryHistoryLog) new BasalDeliveryHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int commandedRateSource, int basalDeliveryFlags, int commandedRate, int profileBasalRate, int algorithmRate, int tempRate
+            589553351L, 641943L, 0, 3, 0, 1000, 65535, 65535
+        ).withHeaderHighNibble(1);
+
+        BasalDeliveryHistoryLog parsedRes = (BasalDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "1711c7de232397cb0900000003000000e803ffffffff00000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(0, parsedRes.getCommandedRateSource());
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.SUSPENDED, parsedRes.getCommandedRateSourceEnum());
+        assertEquals(3, parsedRes.getBasalDeliveryFlags());
+        assertEquals(0, parsedRes.getCommandedRate());
+        assertEquals(1000, parsedRes.getProfileBasalRate());
+        assertEquals(65535, parsedRes.getAlgorithmRate());
+        assertEquals(65535, parsedRes.getTempRate());
+    }
+
+    @Test
+    public void testCommandedRateSourceEnum() {
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.SUSPENDED, BasalDeliveryHistoryLog.CommandedRateSource.fromId(0));
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.PROFILE, BasalDeliveryHistoryLog.CommandedRateSource.fromId(1));
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.TEMP_RATE, BasalDeliveryHistoryLog.CommandedRateSource.fromId(2));
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.ALGORITHM, BasalDeliveryHistoryLog.CommandedRateSource.fromId(3));
+        assertEquals(BasalDeliveryHistoryLog.CommandedRateSource.TEMP_RATE_AND_ALGORITHM, BasalDeliveryHistoryLog.CommandedRateSource.fromId(4));
+        assertNull(BasalDeliveryHistoryLog.CommandedRateSource.fromId(5));
+        assertNull(new BasalDeliveryHistoryLog(9, 0, 1000, 65535, 65535).getCommandedRateSourceEnum());
     }
 }


### PR DESCRIPTION
Refs jwoglom/pumpX2#77

## Summary

`BasalDeliveryHistoryLog` (opcode 279, `LID_BASAL_DELIVERY`) parsed bytes 12-13 as padding and serialized them as zeros. This PR:

- Decodes bytes 12-13 as `basalDeliveryFlags` (uint16 LE) with a `getBasalDeliveryFlags()` getter, and round-trips the value through a new constructor overload and `buildCargo` overload. The existing constructor / `buildCargo` signatures keep working and delegate with flags = 0.
- Adds a `CommandedRateSource` enum (`SUSPENDED=0`, `PROFILE=1`, `TEMP_RATE=2`, `ALGORITHM=3`, `TEMP_RATE_AND_ALGORITHM=4`) with `fromId`, plus `getCommandedRateSourceEnum()` returning `null` for unknown ids, following the style of `BolusDeliveryHistoryLog.BolusSource`.

## Evidence (from the capture analysed on the issue)

Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture; 798 opcode-279 records, ~49k records total across this and an earlier capture.

**Bytes 12-13** take only the values 0 and 3:
- 3 in 471/471 delivering records where any of the five rate fields changed vs the previous record, or a TempRateActivated / TempRateCompleted / PumpingSuspended / PumpingResumed fell in the 5-minute interval;
- 0 in 306/306 steady-state delivering records;
- 3 in 19/20 records written while suspended;
- it is **not** a temp-rate indicator: 0 in 304 records with an active temp rate.

Tandem's export does not name this field, so it is exposed raw with this description in the javadoc.

**`commandedRateSource` (bytes 10-11)**:
- 2 in 768 records, `commandedRate == tempRate` in 768/768;
- 0 in 20 records, all suspended, `commandedRate == 0`, `tempRate == algorithmRate == 0xFFFF`;
- 1 in 10 records, `commandedRate == profileBasalRate` in 10/10;
- 3 was observed in an earlier Control-IQ capture, where it predicted `algorithmRate != 0xFFFF`;
- 4 comes from Tandem's export value map and has not been observed.

## Tests

`BasalDeliveryHistoryLogTest`:
- Updated the stale class comment about bytes 12-13.
- Existing three tests unchanged in construction (they use the no-flags constructor and records with zeros at bytes 12-13); they now also assert `getBasalDeliveryFlags() == 0` and the enum mapping.
- Added fixtures parsing observed payloads, asserting all decoded fields and the cargo round trip:
  - `testBasalDeliveryHistoryLog_tempRateStart_flags3` (src 2, flags 3, 1600/1000/0xFFFF/1600)
  - `testBasalDeliveryHistoryLog_tempRateZero_flags3` (src 2, flags 3, temp rate 0)
  - `testBasalDeliveryHistoryLog_tempRateSteadyState_flags0` (src 2, flags 0, temp rate 0 unchanged)
  - `testBasalDeliveryHistoryLog_tempRateActiveSteadyState_flags0` (src 2, flags 0, 900 mU/hr temp rate active)
  - `testBasalDeliveryHistoryLog_profileSegmentChange_flags3` (src 2, flags 3, profile 1000 -> 1200)
  - `testBasalDeliveryHistoryLog_suspended_flags3` (src 0, flags 3, algorithm/temp 0xFFFF)
  - `testCommandedRateSourceEnum` (id mapping incl. null for unknown)

Executed locally: `./gradlew :messages:test --tests '*BasalDeliveryHistoryLogTest*' --offline --no-daemon -q` — 10 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_