### PR TITLE
BolusDeliveryHistoryLog: rename reserved byte to remoteId

### DIFF
--- a/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLog.java
+++ b/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLog.java
@@ -19,7 +19,7 @@ public class BolusDeliveryHistoryLog extends HistoryLog {
     private int bolusDeliveryStatusId;
     private int bolusTypeBitmask;
     private int bolusSource;
-    private int reserved;
+    private int remoteId;
     private int requestedNow;
     private int requestedLater;
     private int correction;
@@ -28,15 +28,15 @@ public class BolusDeliveryHistoryLog extends HistoryLog {
     
     public BolusDeliveryHistoryLog() {}
     
-    public BolusDeliveryHistoryLog(long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatusId, Set<BolusType> bolusTypes, BolusSource bolusSource, int reserved, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal) {
-        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusID, bolusDeliveryStatusId, BolusType.toBitmask(bolusTypes.toArray(new BolusType[]{})), bolusSource.id(), reserved, requestedNow, requestedLater, correction, extendedDurationRequested, deliveredTotal);
+    public BolusDeliveryHistoryLog(long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatusId, Set<BolusType> bolusTypes, BolusSource bolusSource, int remoteId, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal) {
+        this.cargo = buildCargo(pumpTimeSec, sequenceNum, bolusID, bolusDeliveryStatusId, BolusType.toBitmask(bolusTypes.toArray(new BolusType[]{})), bolusSource.id(), remoteId, requestedNow, requestedLater, correction, extendedDurationRequested, deliveredTotal);
         this.pumpTimeSec = pumpTimeSec;
         this.sequenceNum = sequenceNum;
         this.bolusID = bolusID;
         this.bolusDeliveryStatusId = bolusDeliveryStatusId;
         this.bolusTypeBitmask = BolusType.toBitmask(bolusTypes.toArray(new BolusType[]{}));
         this.bolusSource = bolusSource.id();
-        this.reserved = reserved;
+        this.remoteId = remoteId;
         this.requestedNow = requestedNow;
         this.requestedLater = requestedLater;
         this.correction = correction;
@@ -57,7 +57,7 @@ public class BolusDeliveryHistoryLog extends HistoryLog {
         this.bolusDeliveryStatusId = raw[12];
         this.bolusTypeBitmask = raw[13];
         this.bolusSource = raw[14];
-        this.reserved = raw[15];
+        this.remoteId = raw[15] & 0xFF;
         this.requestedNow = Bytes.readShort(raw, 16);
         this.requestedLater = Bytes.readShort(raw, 18);
         this.correction = Bytes.readShort(raw, 20);
@@ -66,7 +66,7 @@ public class BolusDeliveryHistoryLog extends HistoryLog {
     }
 
     
-    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatus, int bolusType, int bolusSource, int reserved, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal) {
+    public static byte[] buildCargo(long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatus, int bolusType, int bolusSource, int remoteId, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal) {
         return Bytes.combine(
             HistoryLog.typeIdBytes(280, 0), // 280 across 2 bytes
             Bytes.toUint32(pumpTimeSec),
@@ -75,7 +75,7 @@ public class BolusDeliveryHistoryLog extends HistoryLog {
             new byte[]{ (byte) bolusDeliveryStatus }, 
             new byte[]{ (byte) bolusType }, 
             new byte[]{ (byte) bolusSource }, 
-            new byte[]{ (byte) reserved },
+            new byte[]{ (byte) remoteId },
             Bytes.firstTwoBytesLittleEndian(requestedNow),
             Bytes.firstTwoBytesLittleEndian(requestedLater), 
             Bytes.firstTwoBytesLittleEndian(correction), 
@@ -95,8 +95,21 @@ public class BolusDeliveryHistoryLog extends HistoryLog {
     public int getBolusSourceId() {
         return bolusSource;
     }
+    /**
+     * Byte 15, named {@code remoteId} in Tandem's data export. In every record observed so far it
+     * equals {@code bolusId & 0xFF} (312/312 records in a Mobi capture and all earlier t:slim X2
+     * fixtures), i.e. the low byte of the bolus ID echoed back. Previously exposed as
+     * {@link #getReserved()}; see https://github.com/jwoglom/pumpx2/issues/78.
+     */
+    public int getRemoteId() {
+        return remoteId;
+    }
+    /**
+     * @deprecated byte 15 is not reserved; use {@link #getRemoteId()}.
+     */
+    @Deprecated
     public int getReserved() {
-        return reserved;
+        return getRemoteId();
     }
     public int getRequestedNow() {
         return requestedNow;

--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLogTest.java
@@ -1,6 +1,7 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
 import com.jwoglom.pumpx2.pump.messages.MessageTester;
@@ -16,7 +17,7 @@ public class BolusDeliveryHistoryLogTest {
     @Test
     public void testBolusDeliveryHistoryLog1() throws DecoderException {
         BolusDeliveryHistoryLog expected = new BolusDeliveryHistoryLog(
-            // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatus, int bolusType, int bolusSource, int reserved, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
+            // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatusId, Set<BolusType> bolusTypes, BolusSource bolusSource, int remoteId, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
                 446066139L, 183687L,
                 1044,
                 0,
@@ -41,7 +42,7 @@ public class BolusDeliveryHistoryLogTest {
     @Test
     public void testBolusDeliveryHistoryLog2() throws DecoderException {
         BolusDeliveryHistoryLog expected = new BolusDeliveryHistoryLog(
-                // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatus, int bolusType, int bolusSource, int reserved, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
+                // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatusId, Set<BolusType> bolusTypes, BolusSource bolusSource, int remoteId, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
                 446175714L, 187031L,
                 1063,
                 0,
@@ -66,7 +67,7 @@ public class BolusDeliveryHistoryLogTest {
     @Test
     public void testBolusDeliveryHistoryLog3() throws DecoderException {
         BolusDeliveryHistoryLog expected = new BolusDeliveryHistoryLog(
-                // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatus, int bolusType, int bolusSource, int reserved, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
+                // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatusId, Set<BolusType> bolusTypes, BolusSource bolusSource, int remoteId, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
                 446175382L, 186993L,
                 1062,
                 1,
@@ -85,6 +86,77 @@ public class BolusDeliveryHistoryLogTest {
                 expected
         );
 
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
+    // Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture.
+    // Byte 15 (remoteId) equalled bolusId & 0xFF in 312/312 BolusDelivery records of that capture;
+    // the three t:slim X2 fixtures above obey the same rule (1044 -> 20, 1063 -> 39, 1062 -> 38).
+    // Both records below belong to bolus 2903 (0x0b57): the "started" record (status 1,
+    // deliveredTotal 0) and the "completed" record (status 0, deliveredTotal 150) written 4 s later.
+    @Test
+    public void testBolusDeliveryHistoryLog_mobiRemoteBolusStarted() throws DecoderException {
+        BolusDeliveryHistoryLog expected = (BolusDeliveryHistoryLog) new BolusDeliveryHistoryLog(
+                // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatusId, Set<BolusType> bolusTypes, BolusSource bolusSource, int remoteId, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
+                589526845L, 640755L,
+                2903,
+                1,
+                Set.of(BolusType.NOW, BolusType.OVERRIDE),
+                BolusSource.BLUETOOTH_REMOTE_BOLUS,
+                0x57,
+                150,
+                0,
+                0,
+                0,
+                0
+        ).withHeaderHighNibble(1);
+
+        BolusDeliveryHistoryLog parsedRes = (BolusDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "18113d772323f3c60900570b0105085796000000000000000000",
+                expected
+        );
+
+        assertEquals(2903, parsedRes.getBolusID());
+        assertEquals(1, parsedRes.getBolusDeliveryStatusId());
+        assertEquals(Set.of(BolusType.NOW, BolusType.OVERRIDE), parsedRes.getBolusTypes());
+        assertEquals(BolusSource.BLUETOOTH_REMOTE_BOLUS, parsedRes.getBolusSource());
+        assertEquals(0x57, parsedRes.getRemoteId());
+        assertEquals(parsedRes.getBolusID() & 0xFF, parsedRes.getRemoteId());
+        assertEquals(parsedRes.getRemoteId(), parsedRes.getReserved());
+        assertEquals(150, parsedRes.getRequestedNow());
+        assertEquals(0, parsedRes.getDeliveredTotal());
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
+    @Test
+    public void testBolusDeliveryHistoryLog_mobiRemoteBolusCompleted() throws DecoderException {
+        BolusDeliveryHistoryLog expected = (BolusDeliveryHistoryLog) new BolusDeliveryHistoryLog(
+                // long pumpTimeSec, long sequenceNum, int bolusID, int bolusDeliveryStatusId, Set<BolusType> bolusTypes, BolusSource bolusSource, int remoteId, int requestedNow, int requestedLater, int correction, int extendedDurationRequested, int deliveredTotal
+                589526849L, 640760L,
+                2903,
+                0,
+                Set.of(BolusType.NOW, BolusType.OVERRIDE),
+                BolusSource.BLUETOOTH_REMOTE_BOLUS,
+                0x57,
+                150,
+                0,
+                0,
+                0,
+                150
+        ).withHeaderHighNibble(1);
+
+        BolusDeliveryHistoryLog parsedRes = (BolusDeliveryHistoryLog) HistoryLogMessageTester.testSingle(
+                "181141772323f8c60900570b0005085796000000000000009600",
+                expected
+        );
+
+        assertEquals(2903, parsedRes.getBolusID());
+        assertEquals(0, parsedRes.getBolusDeliveryStatusId());
+        assertEquals(Set.of(BolusType.NOW, BolusType.OVERRIDE), parsedRes.getBolusTypes());
+        assertEquals(BolusSource.BLUETOOTH_REMOTE_BOLUS, parsedRes.getBolusSource());
+        assertEquals(parsedRes.getBolusID() & 0xFF, parsedRes.getRemoteId());
+        assertEquals(150, parsedRes.getRequestedNow());
+        assertEquals(150, parsedRes.getDeliveredTotal());
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
 }


### PR DESCRIPTION
Refs jwoglom/pumpX2#78

## Summary

Byte 15 of `LID_BOLUS_DELIVERY` (opcode 280) is not padding. It is Tandem's `remoteId`, carried as the low byte of the bolus id. This PR renames the `reserved` field to `remoteId`, documents it, and adds two observed-payload fixtures.

## Evidence

- In a Mobi BLE capture with 312 BolusDelivery records (156 boluses, all `bolusSource = 8` BLUETOOTH_REMOTE_BOLUS), byte 15 equalled `bolusId & 0xFF` in **312/312** records.
- The three fixtures already in `BolusDeliveryHistoryLogTest` (t:slim X2) obey the same rule: bolusId 1044 -> 20, 1063 -> 39, 1062 -> 38.
- Under the Tandem Source byte-reversed-word mirror, BLE byte 15 lands at cloud offset 16, which is where tconnectsync reads `remoteId`.
- `bolusTypeBitmask = 5` (`NOW | OVERRIDE`) in all 312 records, consistent with Trio's remote boluses (`userOverride = 1` in the paired Msg2, no carbs, no correction).

## Changes

`messages/.../response/historyLog/BolusDeliveryHistoryLog.java`
- Rename the field and the constructor / `buildCargo` parameters from `reserved` to `remoteId`; add `getRemoteId()` with a javadoc explaining the evidence and linking the issue.
- Keep `getReserved()` as `@Deprecated`, delegating to `getRemoteId()`, so existing callers still compile. A repo-wide grep (messages, androidLib, cliparser, sampleapp) found no callers of `getReserved()` on this class.
- Read byte 15 unsigned (`raw[15] & 0xFF`) so the documented `bolusId & 0xFF` relation also holds for bolus ids whose low byte is >= 0x80. The cargo round trip is unchanged since `buildCargo` already casts to `byte`.
- Note: `verboseToString()` / `jsonToString()` use field-name reflection, so their output for this log now shows `remoteId=` instead of `reserved=`. Any consumer keying on that string would need to follow the rename.

`messages/.../response/historyLog/BolusDeliveryHistoryLogTest.java`
- Fixed the stale parameter-name comments (they referred to `int bolusType, int bolusSource` while the constructor takes `Set<BolusType>` / `BolusSource`).
- Added two fixtures from the capture, both for bolus 2903 (`0x0b57`), using `.withHeaderHighNibble(1)` because these records carry header high nibble 1 (`1811`):
  - `testBolusDeliveryHistoryLog_mobiRemoteBolusStarted` — `18113d772323f3c60900570b0105085796000000000000000000` (pumpTimeSec 589526845, seq 640755, status 1, requestedNow 150, deliveredTotal 0)
  - `testBolusDeliveryHistoryLog_mobiRemoteBolusCompleted` — `181141772323f8c60900570b0005085796000000000000009600` (pumpTimeSec 589526849, seq 640760, status 0, requestedNow 150, deliveredTotal 150)
  - Both assert `getRemoteId() == getBolusID() & 0xFF` (0x57), `BolusSource.BLUETOOTH_REMOTE_BOLUS`, the type set `{NOW, OVERRIDE}`, and the cargo round trip.

## Tests

Executed locally:
- `./gradlew :messages:compileJava :messages:compileTestJava --offline --no-daemon -q` — passes (only the expected deprecation note for the `getReserved()` assertion in the test).
- `./gradlew :messages:test --tests '*BolusDeliveryHistoryLogTest*' --offline --no-daemon -q` — 5 tests, 0 failures, 0 errors (3 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_