### PR TITLE
BolusCompletedHistoryLog: add Mobi fixtures from observed BLE capture (refs #42)

### DIFF
--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusCompletedHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusCompletedHistoryLogTest.java
@@ -3,6 +3,9 @@ package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jwoglom.pumpx2.pump.messages.response.currentStatus.LastBolusStatusAbstractResponse;
 
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
@@ -41,5 +44,37 @@ public class BolusCompletedHistoryLogTest {
 
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
         assertEquals(Instant.parse("2022-02-19T12:07:28Z"), parsedRes.getPumpTimeSecInstant());
+    }
+
+    @Test
+    public void testBolusCompletedHistoryLog_mobiRemoteBolus() throws DecoderException {
+        // Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture.
+        // Remote (BLE) bolus id 2903, 0.15u requested and delivered in full. Header high nibble is 1.
+        // In 156/156 records from this capture, completionStatus@10 was 3 (COMPLETE) and bolusId@12
+        // matched the BolusActivated/BolusDelivery records for the same bolus, confirming this layout.
+        BolusCompletedHistoryLog expected = new BolusCompletedHistoryLog(
+                // long pumpTimeSec, long sequenceNum, int completionStatus, int bolusId, float iob, float insulinDelivered, float insulinRequested, int headerHighNibble
+                589526849L, 640762L, 3, 2903,
+                Float.intBitsToFloat(0x3fb21f75), // ~1.3916
+                Float.intBitsToFloat(0x3e19999a), // 0.15
+                Float.intBitsToFloat(0x3e19999a), // 0.15
+                1
+        );
+
+        BolusCompletedHistoryLog parsedRes = (BolusCompletedHistoryLog) HistoryLogMessageTester.testSingle(
+                "141041772323fac609000300570b751fb23f9a99193e9a99193e",
+                expected
+        );
+
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(Instant.parse("2026-09-06T05:27:29Z"), parsedRes.getPumpTimeSecInstant());
+        assertEquals(3, parsedRes.getCompletionStatusId());
+        assertEquals(LastBolusStatusAbstractResponse.BolusStatus.COMPLETE, parsedRes.getCompletionStatus());
+        assertEquals(2903, parsedRes.getBolusId());
+        assertEquals(Float.intBitsToFloat(0x3fb21f75), parsedRes.getIob(), 0.0F);
+        assertEquals(Float.intBitsToFloat(0x3e19999a), parsedRes.getInsulinRequested(), 0.0F);
+        // delivered == requested bit-for-bit in all 156 observed records
+        assertEquals(parsedRes.getInsulinRequested(), parsedRes.getInsulinDelivered(), 0.0F);
+        assertTrue(Math.abs(parsedRes.getInsulinDelivered() - parsedRes.getInsulinRequested()) <= HistoryLog.INSULIN_FLOAT_EPSILON);
     }
 }


### PR DESCRIPTION
Refs jwoglom/pumpX2#42

Test-only change: adds a fixture to `BolusCompletedHistoryLogTest` parsing a 26-byte record observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture. The record (`141041772323fac609000300570b751fb23f9a99193e9a99193e`, header high nibble 1) is the completion of remote (BLE) bolus id 2903 for 0.15u. Across 156 BolusCompleted records in the capture, `completionStatus@10` was 3 (`COMPLETE`) in every record and `bolusId@12` matched the BolusActivated/BolusDelivery id for the same bolus in 156/156, confirming the existing Java layout on the wire (the Python/cloud-export reading has the two fields transposed because of the export's byte-reversed-word mirror, not because the wire layout differs). `insulinDelivered` equalled `insulinRequested` bit-for-bit in all 156 records. Only completion status 3 occurred in the capture, so values 1, 2, 5, 6 remain unverified on the wire. Float expectations are built via `Float.intBitsToFloat` from the exact bit patterns so the round trip is byte-exact. No message class is modified.

Tests added:
- `BolusCompletedHistoryLogTest.testBolusCompletedHistoryLog_mobiRemoteBolus` — asserts byte-exact round trip, pumpTimeSec instant (2026-09-06T05:27:29Z), `completionStatusId == 3` / `BolusStatus.COMPLETE`, `bolusId == 2903`, iob/requested bit patterns, and `insulinDelivered == insulinRequested`.

Executed locally: `./gradlew :messages:test --tests '*BolusCompletedHistoryLogTest*' --offline --no-daemon -q` — 3 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_