### PR TITLE
ControlIQPcmChangeHistoryLog: add Mobi fixtures from observed BLE capture (refs #75)

### DIFF
--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLogTest.java
@@ -1,6 +1,9 @@
 package com.jwoglom.pumpx2.pump.messages.response.historyLog;
 
 import static com.jwoglom.pumpx2.pump.messages.MessageTester.assertHexEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
@@ -36,5 +39,78 @@ public class ControlIQPcmChangeHistoryLogTest {
                 expected
         );
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+    }
+
+    // Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture.
+    // One PCM change record is written on each suspend and each resume (8 records, 4 pairs):
+    // currentPcm/previousPcm swap between NO_CONTROL (0) and OPEN_LOOP (1), pumpSuspended@12 flips
+    // with the suspend state, cgmAvailable@14 is 0 throughout (no CGM on the pump),
+    // closedLoopPreferred@15 is 0 (Control-IQ off), and all five booleans are strictly 0/1.
+    @Test
+    public void testControlIQPcmChangeHistoryLog_MobiSuspend() throws DecoderException {
+        ControlIQPcmChangeHistoryLog expected = (ControlIQPcmChangeHistoryLog) new ControlIQPcmChangeHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int currentPcm, int previousPcm,
+            // int pumpSuspended, int calculationAvailable, int cgmAvailable,
+            // int closedLoopPreferred, int sufficientClosedLoopParams
+            589553316L, 641937L, 0, 1, 1, 1, 0, 0, 1
+        ).withHeaderHighNibble(1);
+
+        ControlIQPcmChangeHistoryLog parsedRes = (ControlIQPcmChangeHistoryLog) HistoryLogMessageTester.testSingle(
+                "e610a4de232391cb090000010101000001000000000000000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+
+        assertEquals(589553316L, parsedRes.getPumpTimeSec());
+        assertEquals(641937L, parsedRes.getSequenceNum());
+        assertEquals(ControlIQPcmChangeHistoryLog.PCM.NO_CONTROL, parsedRes.getCurrentPcm());
+        assertEquals(ControlIQPcmChangeHistoryLog.PCM.OPEN_LOOP, parsedRes.getPreviousPcm());
+        assertEquals(0, parsedRes.getCurrentPcmId());
+        assertEquals(1, parsedRes.getPreviousPcmId());
+        assertTrue(parsedRes.isPumpSuspended());
+        assertTrue(parsedRes.isCalculationAvailable());
+        assertFalse(parsedRes.isCgmAvailable());
+        assertFalse(parsedRes.isClosedLoopPreferred());
+        assertTrue(parsedRes.isSufficientClosedLoopParams());
+        assertEquals(1, parsedRes.getPumpSuspendedRaw());
+        assertEquals(1, parsedRes.getCalculationAvailableRaw());
+        assertEquals(0, parsedRes.getCgmAvailableRaw());
+        assertEquals(0, parsedRes.getClosedLoopPreferredRaw());
+        assertEquals(1, parsedRes.getSufficientClosedLoopParamsRaw());
+    }
+
+    // Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture.
+    // The resume paired with the suspend above: the PCM values swap back and pumpSuspended clears.
+    @Test
+    public void testControlIQPcmChangeHistoryLog_MobiResume() throws DecoderException {
+        ControlIQPcmChangeHistoryLog expected = (ControlIQPcmChangeHistoryLog) new ControlIQPcmChangeHistoryLog(
+            // long pumpTimeSec, long sequenceNum, int currentPcm, int previousPcm,
+            // int pumpSuspended, int calculationAvailable, int cgmAvailable,
+            // int closedLoopPreferred, int sufficientClosedLoopParams
+            589555699L, 642015L, 1, 0, 0, 1, 0, 0, 1
+        ).withHeaderHighNibble(1);
+
+        ControlIQPcmChangeHistoryLog parsedRes = (ControlIQPcmChangeHistoryLog) HistoryLogMessageTester.testSingle(
+                "e610f3e72323dfcb090001000001000001000000000000000000",
+                expected
+        );
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+
+        assertEquals(589555699L, parsedRes.getPumpTimeSec());
+        assertEquals(642015L, parsedRes.getSequenceNum());
+        assertEquals(ControlIQPcmChangeHistoryLog.PCM.OPEN_LOOP, parsedRes.getCurrentPcm());
+        assertEquals(ControlIQPcmChangeHistoryLog.PCM.NO_CONTROL, parsedRes.getPreviousPcm());
+        assertEquals(1, parsedRes.getCurrentPcmId());
+        assertEquals(0, parsedRes.getPreviousPcmId());
+        assertFalse(parsedRes.isPumpSuspended());
+        assertTrue(parsedRes.isCalculationAvailable());
+        assertFalse(parsedRes.isCgmAvailable());
+        assertFalse(parsedRes.isClosedLoopPreferred());
+        assertTrue(parsedRes.isSufficientClosedLoopParams());
+        assertEquals(0, parsedRes.getPumpSuspendedRaw());
+        assertEquals(1, parsedRes.getCalculationAvailableRaw());
+        assertEquals(0, parsedRes.getCgmAvailableRaw());
+        assertEquals(0, parsedRes.getClosedLoopPreferredRaw());
+        assertEquals(1, parsedRes.getSufficientClosedLoopParamsRaw());
     }
 }


### PR DESCRIPTION
Refs jwoglom/pumpX2#75

Test-only change: adds two observed opcode 230 (`LID_AA_PCM_CHANGE`) records from a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture. The capture contained 8 such records, one pair per suspend/resume, matching the layout from #119. In the suspend record `currentPcm`/`previousPcm` are `NO_CONTROL`/`OPEN_LOOP` and `pumpSuspended@12` is 1; in the paired resume record they swap back and `pumpSuspended` clears. `cgmAvailable@14` is 0 throughout (no CGM on the pump), `closedLoopPreferred@15` is 0 (Control-IQ off), `calculationAvailable@13` and `sufficientClosedLoopParams@16` are 1, and all five booleans are strictly 0/1. No message class is modified.

Tests added to `ControlIQPcmChangeHistoryLogTest`:
- `testControlIQPcmChangeHistoryLog_MobiSuspend` — `e610a4de232391cb090000010101000001000000000000000000` (pumpTimeSec 589553316, seq 641937)
- `testControlIQPcmChangeHistoryLog_MobiResume` — `e610f3e72323dfcb090001000001000001000000000000000000` (pumpTimeSec 589555699, seq 642015)

Both follow the existing pattern (`HistoryLogMessageTester.testSingle` + `assertHexEquals` on the cargo, with `.withHeaderHighNibble(1)`) and additionally assert every accessor: `getCurrentPcm()`/`getPreviousPcm()` enum values, the raw PCM ids, the five `is*()` booleans and their `*Raw()` counterparts, plus `getPumpTimeSec()`/`getSequenceNum()`.

Executed locally with `./gradlew :messages:test --tests '*ControlIQPcmChangeHistoryLogTest*' --offline --no-daemon -q`: 4 tests (2 existing + 2 new), 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_