### PR TITLE
BolusRequestedMsg3HistoryLog: add Mobi fixtures from observed BLE capture (refs #52)

### DIFF
--- a/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg3HistoryLogTest.java
+++ b/messages/src/test/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusRequestedMsg3HistoryLogTest.java
@@ -41,4 +41,30 @@ public class BolusRequestedMsg3HistoryLogTest {
 
         assertHexEquals(expected.getCargo(), parsedRes.getCargo());
     }
+
+    // Observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired), Sept 2026 BLE capture.
+    // Remote (BLE) bolus id 2903 for 0.15 U: bolusId@10 matched the paired BolusActivated / BolusDelivery
+    // records in 156/156 boluses, spare@12 was 0 in 156/156, and foodBolusSize == totalBolusSize (correction 0).
+    // Header high nibble is 1 on this firmware. Floats are built from the exact bit pattern so the
+    // cargo round-trip is byte-exact.
+    @Test
+    public void testBolusRequestedMsg3HistoryLog_mobiRemoteBolus() throws DecoderException {
+        float bolusSize = Float.intBitsToFloat(0x3e19999a); // 0.15 U (bytes 9a99193e)
+        BolusRequestedMsg3HistoryLog expected = (BolusRequestedMsg3HistoryLog) new BolusRequestedMsg3HistoryLog(
+                // long pumpTimeSec, long sequenceNum, int bolusId, int spare, float foodBolusSize, float correctionBolusSize, float totalBolusSize
+                589526830L, 640748L, 2903, 0, bolusSize, 0.0F, bolusSize
+        ).withHeaderHighNibble(1);
+
+        BolusRequestedMsg3HistoryLog parsedRes = (BolusRequestedMsg3HistoryLog) HistoryLogMessageTester.testSingle(
+                "42102e772323ecc60900570b00009a99193e000000009a99193e",
+                expected
+        );
+
+        assertHexEquals(expected.getCargo(), parsedRes.getCargo());
+        assertEquals(2903, parsedRes.getBolusId());
+        assertEquals(0, parsedRes.getSpare());
+        assertEquals(0x3e19999a, Float.floatToIntBits(parsedRes.getFoodBolusSize()));
+        assertEquals(0.0F, parsedRes.getCorrectionBolusSize(), 0.0F);
+        assertEquals(parsedRes.getFoodBolusSize(), parsedRes.getTotalBolusSize(), 0.0F);
+    }
 }


### PR DESCRIPTION
Refs jwoglom/pumpX2#52

Test-only change: adds a fixture for LID_BOLUS_REQUESTED_MSG3 (opCode 66) parsed from an actual record observed on a Tandem Mobi driven by Trio (Control-IQ off, no CGM paired) in a Sept 2026 BLE capture. The record is for remote (BLE) bolus id 2903 requesting 0.15 U: `bolusId@10` matched the paired BolusActivated / BolusDelivery records in 156/156 boluses, `spare@12` was 0 in 156/156, and `foodBolusSize == totalBolusSize ==` the units Trio requested with `correctionBolusSize` = 0. The existing parser already decodes this layout correctly, so no message class is modified; the fixture pins down the Mobi header high nibble (1) and the byte-exact float round trip (floats built via `Float.intBitsToFloat(0x3e19999a)`).

Tests added (in the existing `BolusRequestedMsg3HistoryLogTest`):
- `testBolusRequestedMsg3HistoryLog_mobiRemoteBolus` — parses `42102e772323ecc60900570b00009a99193e000000009a99193e` (pumpTimeSec 589526830, sequenceNum 640748), asserts the full verbose round trip and cargo hex equality, plus bolusId=2903, spare=0, foodBolusSize bit pattern 0x3e19999a, correctionBolusSize=0.0, and foodBolusSize == totalBolusSize.

Tests executed locally: `./gradlew :messages:test --tests '*BolusRequestedMsg3HistoryLogTest*' --offline --no-daemon -q` — 3 tests run (2 existing + 1 new), 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu

---
_Generated by [Claude Code](https://claude.ai/code/session_016AMLmoDhMuccKDSEFMZriu)_